### PR TITLE
look up the new kinds of constructors generated by purescript

### DIFF
--- a/src/React/DOM.purs
+++ b/src/React/DOM.purs
@@ -281,9 +281,9 @@ module React.DOM where
     \   var result = {};                                       \
     \   for (var i = 0, len = props.length; i < len; i++) {    \
     \     var prop = props[i];                                 \
-    \     var name = prop.ctor.substring(10);                  \
+    \     var name = prop.constructor.name;                    \
     \     name = name[0].toLowerCase() + name.substring(1);    \
-    \     var val = prop.values[0];                            \
+    \     var val = prop.value0;                               \
     \     /* Until React.js handles data and aria like style*/ \
     \     /* we have to unload the properties.*/               \
     \     if (name === 'data' || name === 'aria') {            \


### PR DESCRIPTION
New to PureScript, but I was playing around and wanted to get this working with the latest build of the PureScript compiler (see https://github.com/purescript/purescript/pull/454 for the change that seems to break `prop.ctor`). Seems to work, but I don't know if there are edge cases I'm missing or something. Feel free to hold off on merging / let me know if you have any comments.
