### PR TITLE
Fixes the div attributes in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ counter = mkUI spec { getInitialState = return 0 } do
     ]
 
 main = do
-  let component = div {} [hello {name: "World"}, counter {}]
+  let component = div [] [hello {name: "World"}, counter {}]
   renderToBody component
 ```
 


### PR DESCRIPTION
As far as I can tell, the first argument to a DOM node is supposed to be a list of attributes, not a record as it appears at the bottom of the README.
