### PR TITLE
Adds a missing argument to `incrementCounter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ hello = mkUI spec do
       text props.name
     ]
 
-incrementCounter = do
+incrementCounter e = do
   val <- readState
   writeState (val + 1)
 


### PR DESCRIPTION
The missing argument to incrementCounter prevents the example in the Readme from compiling. As a side note, the error message is rather unhelpful:

```
Warning: Error at src/Main.purs line 23, column 7 - line 24, column 5:
Error in declaration counter
Cannot unify Control.Monad.Eff.Eff with Prim.Function. Use --force to continue.
```