### PR TITLE
Topic/create element

### DIFF
--- a/docs/React.md
+++ b/docs/React.md
@@ -160,6 +160,14 @@ type UISpec props state eff = { render :: Render props state eff, displayName ::
 
 A specification of a component.
 
+#### `UIFactory`
+
+``` purescript
+type UIFactory props = props -> UI
+```
+
+Factory function for components.
+
 #### `spec`
 
 ``` purescript
@@ -211,7 +219,7 @@ Transform the component state by applying a function.
 #### `mkUI`
 
 ``` purescript
-mkUI :: forall props state eff. UISpec props state eff -> props -> UI
+mkUI :: forall props state eff. UISpec props state eff -> UIFactory props
 ```
 
 Create a component from a component spec.
@@ -247,5 +255,13 @@ renderToElementById :: forall eff. String -> UI -> Eff (dom :: DOM | eff) UI
 ```
 
 Render a component to the element with the specified ID.
+
+#### `createElement`
+
+``` purescript
+createElement :: forall props. UIFactory props -> props -> Array UI -> UI
+```
+
+Create an element from a component factory.
 
 

--- a/docs/React.md
+++ b/docs/React.md
@@ -192,6 +192,14 @@ getRefs :: forall write eff. UIRef -> Eff (refs :: ReactRefs (Read write) | eff)
 
 Read the component refs.
 
+#### `getChildren`
+
+``` purescript
+getChildren :: forall props eff. UIRef -> Eff (props :: ReactProps props | eff) (Array UI)
+```
+
+Read the component children property.
+
 #### `writeState`
 
 ``` purescript

--- a/src/React.js
+++ b/src/React.js
@@ -15,6 +15,12 @@ exports.getRefs = function(ctx) {
     };
 };
 
+exports.getChildren = function(ctx) {
+  return function() {
+    return ctx.props.children;
+  };
+};
+
 exports.writeState = function(ctx) {
     return function(state) {
         return function() {

--- a/src/React.js
+++ b/src/React.js
@@ -79,3 +79,11 @@ exports.renderToElementById = function(id) {
         }
     }
 };
+
+exports.createElement = function(factory) {
+  return function(props) {
+    return function(children){
+      return React.createElement.apply(React, [factory, props].concat(children));
+    };
+  };
+};

--- a/src/React.purs
+++ b/src/React.purs
@@ -22,6 +22,7 @@ module React
   , Render()
 
   , UISpec()
+  , UIFactory()
 
   , Event()
   , MouseEvent()
@@ -45,6 +46,7 @@ module React
   , renderToString
   , renderToBody
   , renderToElementById
+  , createElement
   ) where
 
 import Prelude
@@ -202,6 +204,9 @@ type UISpec props state eff =
              ) Unit
   }
 
+-- | Factory function for components.
+type UIFactory props = props -> UI
+
 -- | Create a component specification.
 spec :: forall props state eff. state -> Render props state eff -> UISpec props state eff
 spec st render =
@@ -250,8 +255,7 @@ transformState ctx f = do
 -- | Create a component from a component spec.
 foreign import mkUI :: forall props state eff.
                          UISpec props state eff ->
-                         props ->
-                         UI
+                         UIFactory props
 
 -- | Create an event handler.
 foreign import handle :: forall eff ev props state result.
@@ -266,3 +270,6 @@ foreign import renderToBody :: forall eff. UI -> Eff (dom :: DOM | eff) UI
 
 -- | Render a component to the element with the specified ID.
 foreign import renderToElementById :: forall eff. String -> UI -> Eff (dom :: DOM | eff) UI
+
+-- | Create an element from a component factory.
+foreign import createElement :: forall props. UIFactory props -> props -> Array UI -> UI

--- a/src/React.purs
+++ b/src/React.purs
@@ -34,6 +34,7 @@ module React
 
   , getProps
   , getRefs
+  , getChildren
 
   , readState
   , writeState
@@ -231,6 +232,11 @@ foreign import getProps :: forall props eff.
 foreign import getRefs :: forall write eff.
                             UIRef ->
                             Eff (refs :: ReactRefs (Read write) | eff) Refs
+
+-- | Read the component children property.
+foreign import getChildren :: forall props eff.
+                                UIRef ->
+                                Eff (props :: ReactProps props | eff) (Array UI)
 
 -- | Write the component state.
 foreign import writeState :: forall state eff.

--- a/test/Container.purs
+++ b/test/Container.purs
@@ -1,0 +1,19 @@
+module Test.Container where
+
+import Prelude
+
+import React
+
+import qualified React.DOM as D
+import qualified React.DOM.Props as P
+
+container = mkUI $ spec unit \ctx -> do
+  children <- getChildren ctx
+
+  let ui = D.div [ P.style { borderColor: "red"
+                           , borderWidth: 2
+                           , padding: 10
+                           }
+                 ] children
+
+  return ui

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -10,8 +10,10 @@ import React
 import qualified React.DOM as D
 import qualified React.DOM.Props as P
 
-foreign import interval :: forall eff a. 
-                             Int -> 
+import Test.Container (container)
+
+foreign import interval :: forall eff a.
+                             Int ->
                              Eff eff a ->
                              Eff eff Unit
 
@@ -19,7 +21,7 @@ hello = mkUI $ spec unit \ctx -> do
   props <- getProps ctx
   return $ D.h1 [ P.className "Hello"
                 , P.style { background: "lightgray" }
-                ] 
+                ]
                 [ D.text "Hello, "
                 , D.text props.name
                 ]
@@ -44,5 +46,13 @@ counter = mkUI counterSpec
                       ]
 
 main = do
-  let component = D.div' [ hello { name: "World" }, counter unit ]
+  let component = D.div' [
+                    hello { name: "World" },
+                    counter unit,
+                    createElement container unit [
+                      D.p [] [ D.text  "This is line one" ],
+                      D.p [] [ D.text "This is line two" ]
+                    ]
+                  ]
+
   renderToBody component


### PR DESCRIPTION
Adds `createElement` that takes a component factory along with a set of props and creates a UI element. I am open for discussion on this one. However, the main use-case is to allow the developer to render their React components from within other React components.