### PR TITLE
Ensure getChildren returns an array

### DIFF
--- a/src/React.js
+++ b/src/React.js
@@ -17,7 +17,15 @@ exports.getRefs = function(ctx) {
 
 exports.getChildren = function(ctx) {
   return function() {
-    return ctx.props.children;
+    var children = ctx.props.children;
+
+    var result = [];
+
+    React.Children.forEach(children, function(child){
+      result.push(child);
+    });
+
+    return result;
   };
 };
 


### PR DESCRIPTION
Resolves #44 

When a single element is provided as a child to the `createElement` call, `getChildren` would return a non-array element. This PR ensures that an array is returned in all cases by constructing a result array using the `React.Children` build-in functions.