### PR TITLE
fix inline styling error

### DIFF
--- a/src/React/DOM/Props.js
+++ b/src/React/DOM/Props.js
@@ -14,13 +14,15 @@ exports.unsafeMkProps = function(key) {
 exports.unsafeUnfoldProps = function(key) {
     return function(value) {
         var result = {};
+        var props = {};
+        props[key] = result;
 
         for (var subprop in value) {
             if (value.hasOwnProperty(subprop)) {
-                result[key + '-' + subprop] = value[subprop];
+                result[subprop] = value[subprop];
             }
         }
 
-        return result;
+        return props;
     };
 };


### PR DESCRIPTION
At the moment inline styles are never rendered by purescript-react. I dont know if this has a negative effect on 

```
aria :: forall ariaAttrs. { | ariaAttrs } -> Props
aria = unsafeUnfoldProps "aria"

_data :: forall dataAttrs. { | dataAttrs } -> Props
_data = unsafeUnfoldProps "data"
```