### PR TITLE
Adds a spec constructor function with getInitialState

### DIFF
--- a/docs/React.md
+++ b/docs/React.md
@@ -230,7 +230,15 @@ A specification of a component.
 spec :: forall props state eff. state -> Render props state eff -> ReactSpec props state eff
 ```
 
-Create a component specification.
+Create a component specification with a provided state.
+
+#### `spec'`
+
+``` purescript
+spec' :: forall props state eff. GetInitialState props state eff -> Render props state eff -> ReactSpec props state eff
+```
+
+Create a component specification with a get initial state function.
 
 #### `ReactClass`
 

--- a/src/React.purs
+++ b/src/React.purs
@@ -38,7 +38,7 @@ module React
 
   , EventHandlerContext()
 
-  , spec
+  , spec, spec'
 
   , getProps
   , getRefs
@@ -244,19 +244,23 @@ type ReactSpec props state eff =
   , componentWillUnmount :: ComponentWillUnmount props state eff
   }
 
--- | Create a component specification.
+-- | Create a component specification with a provided state.
 spec :: forall props state eff. state -> Render props state eff -> ReactSpec props state eff
-spec st renderFn =
-  { render:                    renderFn
-  , displayName:               ""
-  , getInitialState:           \_ -> pure st
-  , componentWillMount:        \_ -> return unit
-  , componentDidMount:         \_ -> return unit
+spec state = spec' (\_ -> pure state)
+
+-- | Create a component specification with a get initial state function.
+spec' :: forall props state eff. GetInitialState props state eff -> Render props state eff -> ReactSpec props state eff
+spec' getInitialState renderFn =
+  { render: renderFn
+  , displayName: ""
+  , getInitialState: getInitialState
+  , componentWillMount: \_ -> return unit
+  , componentDidMount: \_ -> return unit
   , componentWillReceiveProps: \_ _ -> return unit
-  , shouldComponentUpdate:     \_ _ _ -> return true
-  , componentWillUpdate:       \_ _ _ -> return unit
-  , componentDidUpdate:        \_ _ _ -> return unit
-  , componentWillUnmount:      \_ -> return unit
+  , shouldComponentUpdate: \_ _ _ -> return true
+  , componentWillUpdate: \_ _ _ -> return unit
+  , componentDidUpdate: \_ _ _ -> return unit
+  , componentWillUnmount: \_ -> return unit
   }
 
 -- | React class for components.


### PR DESCRIPTION
I thought it might be handy to have a constructor that allows for passing in the `getInitialState` function. Sometimes the initial state might be derived from the props and there may not be a good plain state value that is known at the time the class is specified.