### PR TITLE
Add writeState with callback

### DIFF
--- a/src/React.js
+++ b/src/React.js
@@ -53,6 +53,20 @@ function writeState(this_) {
 }
 exports.writeState = writeState;
 
+function writeStateWithCallback(this_, cb) {
+  return function(state){
+    return function(cb){
+      return function() {
+        this_.setState({
+          state: state
+        }, cb);
+        return state;
+      };
+    };
+  };
+}
+exports.writeStateWithCallback = writeStateWithCallback;
+
 function readState(this_) {
   return function(){
     return this_.state.state;

--- a/src/React.purs
+++ b/src/React.purs
@@ -47,6 +47,7 @@ module React
 
   , readState
   , writeState
+  , writeStateWithCallback
   , transformState
 
   , handle
@@ -280,6 +281,9 @@ foreign import getChildren :: forall props state eff. ReactThis props state -> E
 
 -- | Write the component state.
 foreign import writeState :: forall props state access eff. ReactThis props state -> state -> Eff (state :: ReactState (write :: Write | access) | eff) state
+
+-- | Write the component state with a callback.
+foreign import writeStateWithCallback :: forall props state access eff. ReactThis props state -> state -> Eff (state :: ReactState (write :: Write | access) | eff) Unit -> Eff (state :: ReactState (write :: Write | access) | eff) state
 
 -- | Read the component state.
 foreign import readState :: forall props state access eff. ReactThis props state -> Eff (state :: ReactState (read :: Read | access) | eff) state


### PR DESCRIPTION
This is needed in order to implement [this](https://github.com/paf31/purescript-thermite/pull/55). `writeState` needs to call a callback for allowing async actions in `purescrtipt-thermite`.