### PR TITLE
Expose unsafe prop

### DIFF
--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -593,3 +593,6 @@ onScroll f = unsafeMkProps "onScroll" (handle f)
 onWheel :: forall eff props state result.
   (Event -> EventHandlerContext eff props state result) -> Props
 onWheel f = unsafeMkProps "onWheel" (handle f)
+
+unsafe :: forall val. String -> val -> Props
+unsafe = unsafeMkProps


### PR DESCRIPTION
Rationale: while binding 3rd party components, such as Material-UI textField, one might want to reuse the same api as the `input` have (array of Props), but then more Props are needed. By exposing unsafe, it's possible to add those:

```
        , textField
            [ P.value state.password
            , P.placeholder "password"
            , P.errorText "ERROR"
            , P.onChange $ E.onValueChange \v -> transformState this (_ { password = v })
            ]
```

where `P.errorText` is defined using the `unsafe` Prop.
