### PR TITLE
Update for react-15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .psci*
 bower_components/
+node_modules/
 output/
 .psc-package
 .psc-ide-port

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "purescript-react",
   "files": [],
   "peerDependencies": {
-    "react": "^0.14.3"
+    "react": "^15.5.4",
+    "create-react-class": "^15.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "purescript-react",
   "files": [],
   "peerDependencies": {
-    "react": "^15.5.4",
-    "create-react-class": "^15.5.3"
+    "react": "^15.6.1",
+    "create-react-class": "^15.6.0"
   }
 }

--- a/src/React.js
+++ b/src/React.js
@@ -2,6 +2,7 @@
 "use strict";
 
 var React = require("react");
+var createReactClass = require("create-react-class");
 
 function getProps(this_) {
   return function(){
@@ -117,7 +118,7 @@ function createClass(spec) {
     }
   };
 
-  return React.createClass(result);
+  return createReactClass(result);
 }
 exports.createClass = createClass;
 

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -458,6 +458,30 @@ security = unsafeMkProps "security"
 unselectable :: Boolean -> Props
 unselectable = unsafeMkProps "unselectable"
 
+onAnimationStart :: forall eff props state result.
+  (Event -> EventHandlerContext eff props state result) -> Props
+onAnimationStart f = unsafeMkProps "onAnimationStart" (handle f)
+
+onAnimationEnd :: forall eff props state result.
+  (Event -> EventHandlerContext eff props state result) -> Props
+onAnimationEnd f = unsafeMkProps "onAnimationEnd" (handle f)
+
+onAnimationIteration :: forall eff props state result.
+  (Event -> EventHandlerContext eff props state result) -> Props
+onAnimationIteration f = unsafeMkProps "onAnimationIteration" (handle f)
+
+onTransitionStart :: forall eff props state result.
+  (Event -> EventHandlerContext eff props state result) -> Props
+onTransitionStart f = unsafeMkProps "onTransitionStart" (handle f)
+
+onTransitionEnd :: forall eff props state result.
+  (Event -> EventHandlerContext eff props state result) -> Props
+onTransitionEnd f = unsafeMkProps "onTransitionEnd" (handle f)
+
+onLoad :: forall eff props state result.
+  (Event -> EventHandlerContext eff props state result) -> Props
+onLoad f = unsafeMkProps "onLoad" (handle f)
+
 onCopy :: forall eff props state result.
   (Event -> EventHandlerContext eff props state result) -> Props
 onCopy f = unsafeMkProps "onCopy" (handle f)
@@ -497,6 +521,10 @@ onChange f = unsafeMkProps "onChange" (handle f)
 onInput :: forall eff props state result.
   (Event -> EventHandlerContext eff props state result) -> Props
 onInput f = unsafeMkProps "onInput" (handle f)
+
+onInvalid :: forall eff props state result.
+  (Event -> EventHandlerContext eff props state result) -> Props
+onInvalid f = unsafeMkProps "onInvalid" (handle f)
 
 onSubmit :: forall eff props state result.
   (Event -> EventHandlerContext eff props state result) -> Props

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -470,10 +470,6 @@ onAnimationIteration :: forall eff props state result.
   (Event -> EventHandlerContext eff props state result) -> Props
 onAnimationIteration f = unsafeMkProps "onAnimationIteration" (handle f)
 
-onTransitionStart :: forall eff props state result.
-  (Event -> EventHandlerContext eff props state result) -> Props
-onTransitionStart f = unsafeMkProps "onTransitionStart" (handle f)
-
 onTransitionEnd :: forall eff props state result.
   (Event -> EventHandlerContext eff props state result) -> Props
 onTransitionEnd f = unsafeMkProps "onTransitionEnd" (handle f)

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -617,3 +617,6 @@ onScroll f = unsafeMkProps "onScroll" (handle f)
 onWheel :: forall eff props state result.
   (Event -> EventHandlerContext eff props state result) -> Props
 onWheel f = unsafeMkProps "onWheel" (handle f)
+
+suppressContentEditableWarning :: Boolean -> Props
+suppressContentEditableWarning = unsafeMkProps "suppressContentEditableWarning"


### PR DESCRIPTION
The bindings now require to install `create-react-class` alongside with `react`.  This suppresses a warning in react-15.  React-16 will not allow to use `React.createClass` and it's migrating towards react classes.