### PR TITLE
refs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,8 @@
     "purescript-eff": "^3.0.0",
     "purescript-prelude": "^3.0.0",
     "purescript-unsafe-coerce": "^3.0.0",
-    "purescript-dom": "^4.5.0"
+    "purescript-maybe": "^3.0.0",
+    "purescript-nullable": "^3.0.0"
   },
   "devDependencies": {
     "purescript-console": "^3.0.0",

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "purescript-eff": "^3.0.0",
     "purescript-prelude": "^3.0.0",
-    "purescript-unsafe-coerce": "^3.0.0"
+    "purescript-unsafe-coerce": "^3.0.0",
+    "purescript-dom": "^4.5.0"
   },
   "devDependencies": {
     "purescript-console": "^3.0.0",

--- a/src/React.js
+++ b/src/React.js
@@ -40,6 +40,30 @@ function getChildren(this_) {
 }
 exports.getChildren = getChildren;
 
+function readRefImpl (this_) {
+  return function(name) {
+    return function() {
+      var refs = this_.refs || {};
+      return refs[name];
+    }
+  }
+}
+exports.readRefImpl = readRefImpl;
+
+function writeRef(this_) {
+  return function(name) {
+    return function(node) {
+      return function() {
+        var refs = this_.refs || {};
+        refs[name] = node;
+        this_.refs = refs;
+        return {};
+      }
+    }
+  }
+}
+exports.writeRef = writeRef;
+
 function writeState(this_) {
   return function(state){
     return function(){

--- a/src/React.purs
+++ b/src/React.purs
@@ -44,6 +44,7 @@ module React
   , getProps
   , getRefs
   , readRef
+  , writeRef
   , getChildren
 
   , readState
@@ -68,9 +69,9 @@ module React
 import Prelude
 
 import Control.Monad.Eff (kind Effect, Eff)
-import DOM.Node.Types (Node, readNode)
-import Data.Foreign (F, Foreign)
-import Data.Foreign.Index (readProp)
+import DOM.Node.Types (Node)
+import Data.Maybe (Maybe)
+import Data.Nullable (Nullable, toMaybe)
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | Name of a tag.
@@ -300,11 +301,22 @@ foreign import getRefs :: forall props state access eff.
   Eff (refs :: ReactRefs (read :: Read | access) | eff) Refs
 
 -- | Read named ref from Refs
-readRef :: forall access eff.
+foreign import readRefImpl :: forall props state access eff.
+  ReactThis props state ->
   String ->
-  Foreign ->
-  Eff (refs :: ReactRefs (read :: Read | access) | eff) (F Node)
-readRef name refs = pure $ join (readNode <$> readProp name refs)
+  Eff (refs :: ReactRefs (read :: Read | access) | eff) (Nullable Node)
+
+readRef :: forall props state access eff.
+  ReactThis props state ->
+  String ->
+  Eff (refs :: ReactRefs (read :: Read | access) | eff) (Maybe Node)
+readRef this name = toMaybe <$> readRefImpl this name
+
+foreign import writeRef :: forall props state access eff.
+  ReactThis props state ->
+  String ->
+  Node ->
+  Eff (refs :: ReactRefs (write :: Write | access) | eff) Unit
 
 -- | Read the component children property.
 foreign import getChildren :: forall props state eff.

--- a/src/React.purs
+++ b/src/React.purs
@@ -69,7 +69,7 @@ import Prelude
 
 import Control.Monad.Eff (kind Effect, Eff)
 import DOM.Node.Types (Node, readNode)
-import Data.Foreign (F, Foreign, toForeign)
+import Data.Foreign (F, Foreign)
 import Data.Foreign.Index (readProp)
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -302,12 +302,9 @@ foreign import getRefs :: forall props state access eff.
 -- | Read named ref from Refs
 readRef :: forall access eff.
   String ->
-  Refs ->
+  Foreign ->
   Eff (refs :: ReactRefs (read :: Read | access) | eff) (F Node)
-readRef name refs = pure $ join (readNode <$> prop)
-  where
-    prop :: F Foreign
-    prop = readProp name (toForeign refs)
+readRef name refs = pure $ join (readNode <$> readProp name refs)
 
 -- | Read the component children property.
 foreign import getChildren :: forall props state eff.

--- a/src/React.purs
+++ b/src/React.purs
@@ -321,7 +321,7 @@ readRef this name = toMaybe <$> readRefImpl this name
 foreign import writeRef :: forall props state access eff.
   ReactThis props state ->
   String ->
-  Ref ->
+  Nullable Ref ->
   Eff (refs :: ReactRefs (write :: Write | access) | eff) Unit
 
 -- | Read the component children property.

--- a/src/React.purs
+++ b/src/React.purs
@@ -300,20 +300,24 @@ foreign import getRefs :: forall props state access eff.
   ReactThis props state ->
   Eff (refs :: ReactRefs (read :: Read | access) | eff) Refs
 
+-- | Ref type.  You can store `Ref` types on `Refs` object (which in
+-- | corresponds to `this.refs`).  Use `ReactDOM.refToNode` if you want to
+-- store a `DOM.Node.Types.Node`
 foreign import data Ref :: Type
 
--- | Read named ref from Refs
 foreign import readRefImpl :: forall props state access eff.
   ReactThis props state ->
   String ->
   Eff (refs :: ReactRefs (read :: Read | access) | eff) (Nullable Ref)
 
+-- | Read named ref from `Refs`.
 readRef :: forall props state access eff.
   ReactThis props state ->
   String ->
   Eff (refs :: ReactRefs (read :: Read | access) | eff) (Maybe Ref)
 readRef this name = toMaybe <$> readRefImpl this name
 
+-- | Write a `Ref` to `Refs`
 foreign import writeRef :: forall props state access eff.
   ReactThis props state ->
   String ->

--- a/src/React.purs
+++ b/src/React.purs
@@ -43,6 +43,7 @@ module React
 
   , getProps
   , getRefs
+  , readRef
   , getChildren
 
   , readState
@@ -65,7 +66,11 @@ module React
   ) where
 
 import Prelude
+
 import Control.Monad.Eff (kind Effect, Eff)
+import DOM.Node.Types (Node, readNode)
+import Data.Foreign (F, Foreign, toForeign)
+import Data.Foreign.Index (readProp)
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | Name of a tag.
@@ -293,6 +298,16 @@ foreign import getProps :: forall props state eff.
 foreign import getRefs :: forall props state access eff.
   ReactThis props state ->
   Eff (refs :: ReactRefs (read :: Read | access) | eff) Refs
+
+-- | Read named ref from Refs
+readRef :: forall access eff.
+  String ->
+  Refs ->
+  Eff (refs :: ReactRefs (read :: Read | access) | eff) (F Node)
+readRef name refs = pure $ join (readNode <$> prop)
+  where
+    prop :: F Foreign
+    prop = readProp name (toForeign refs)
 
 -- | Read the component children property.
 foreign import getChildren :: forall props state eff.

--- a/src/React.purs
+++ b/src/React.purs
@@ -19,6 +19,7 @@ module React
   , ReactRefs
 
   , Refs
+  , Ref
 
   , Render
   , GetInitialState
@@ -69,7 +70,6 @@ module React
 import Prelude
 
 import Control.Monad.Eff (kind Effect, Eff)
-import DOM.Node.Types (Node)
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toMaybe)
 import Unsafe.Coerce (unsafeCoerce)
@@ -300,22 +300,24 @@ foreign import getRefs :: forall props state access eff.
   ReactThis props state ->
   Eff (refs :: ReactRefs (read :: Read | access) | eff) Refs
 
+foreign import data Ref :: Type
+
 -- | Read named ref from Refs
 foreign import readRefImpl :: forall props state access eff.
   ReactThis props state ->
   String ->
-  Eff (refs :: ReactRefs (read :: Read | access) | eff) (Nullable Node)
+  Eff (refs :: ReactRefs (read :: Read | access) | eff) (Nullable Ref)
 
 readRef :: forall props state access eff.
   ReactThis props state ->
   String ->
-  Eff (refs :: ReactRefs (read :: Read | access) | eff) (Maybe Node)
+  Eff (refs :: ReactRefs (read :: Read | access) | eff) (Maybe Ref)
 readRef this name = toMaybe <$> readRefImpl this name
 
 foreign import writeRef :: forall props state access eff.
   ReactThis props state ->
   String ->
-  Node ->
+  Ref ->
   Eff (refs :: ReactRefs (write :: Write | access) | eff) Unit
 
 -- | Read the component children property.

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -297,6 +297,9 @@ radioGroup = unsafeMkProps "radioGroup"
 readOnly :: Boolean -> Props
 readOnly = unsafeMkProps "readOnly"
 
+ref :: String -> Props
+ref = unsafeMkProps "ref"
+
 rel :: String -> Props
 rel = unsafeMkProps "rel"
 

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -305,13 +305,13 @@ ref = unsafeMkProps "ref"
 
 -- | You can use `writeRef` to store a reference on `Refs`.
 -- | ``` purescrript
--- | div [ refCb (writeRef this "inputEl") ] [...]
+-- | div [ withRef (writeRef this "inputElement") ] [...]
 -- | ```
-refCb
+withRef
   :: forall access eff
    . (Ref -> Eff (refs :: ReactRefs (write :: Write | access) | eff) Unit)
   -> Props
-refCb cb = unsafeMkProps "ref" (unsafePerformEff <<< cb)
+withRef cb = unsafeMkProps "ref" (unsafePerformEff <<< cb)
 
 rel :: String -> Props
 rel = unsafeMkProps "rel"

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -2,6 +2,7 @@ module React.DOM.Props where
 
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Unsafe (unsafePerformEff)
+import Data.Nullable (Nullable)
 import Prelude (Unit, (<<<))
 import React (Event, EventHandlerContext, KeyboardEvent, MouseEvent, ReactRefs, Ref, Write, handle)
 
@@ -309,7 +310,7 @@ ref = unsafeMkProps "ref"
 -- | ```
 withRef
   :: forall access eff
-   . (Ref -> Eff (refs :: ReactRefs (write :: Write | access) | eff) Unit)
+   . (Nullable Ref -> Eff (refs :: ReactRefs (write :: Write | access) | eff) Unit)
   -> Props
 withRef cb = unsafeMkProps "ref" (unsafePerformEff <<< cb)
 

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -2,9 +2,8 @@ module React.DOM.Props where
 
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Unsafe (unsafePerformEff)
-import DOM.Node.Types (Node)
 import Prelude (Unit, (<<<))
-import React (Event, EventHandlerContext, KeyboardEvent, MouseEvent, ReactRefs, Write, handle)
+import React (Event, EventHandlerContext, KeyboardEvent, MouseEvent, ReactRefs, Ref, Write, handle)
 
 foreign import data Props :: Type
 
@@ -310,7 +309,7 @@ ref = unsafeMkProps "ref"
 -- | ```
 refCb
   :: forall access eff
-   . (Node -> Eff (refs :: ReactRefs (write :: Write | access) | eff) Unit)
+   . (Ref -> Eff (refs :: ReactRefs (write :: Write | access) | eff) Unit)
   -> Props
 refCb cb = unsafeMkProps "ref" (unsafePerformEff <<< cb)
 

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -300,6 +300,12 @@ readOnly = unsafeMkProps "readOnly"
 ref :: String -> Props
 ref = unsafeMkProps "ref"
 
+refCb
+  :: forall props state
+   . (ReactThis props state -> Eff (refs :: ReactRefs (write :: Write | access) | eff)) 
+  -> Props
+refCb cb = unsafeMkProps "ref" (unsafePerformEff <<< cb)
+
 rel :: String -> Props
 rel = unsafeMkProps "rel"
 

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -1,6 +1,10 @@
 module React.DOM.Props where
 
-import React (Event, EventHandlerContext, KeyboardEvent, MouseEvent, handle)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Unsafe (unsafePerformEff)
+import DOM.Node.Types (Node)
+import Prelude (Unit, (<<<))
+import React (Event, EventHandlerContext, KeyboardEvent, MouseEvent, ReactRefs, Write, handle)
 
 foreign import data Props :: Type
 
@@ -300,9 +304,13 @@ readOnly = unsafeMkProps "readOnly"
 ref :: String -> Props
 ref = unsafeMkProps "ref"
 
+-- | You can use `writeRef` to store a reference on `Refs`.
+-- | ``` purescrript
+-- | div [ refCb (writeRef this "inputEl") ] [...]
+-- | ```
 refCb
-  :: forall props state
-   . (ReactThis props state -> Eff (refs :: ReactRefs (write :: Write | access) | eff)) 
+  :: forall access eff
+   . (Node -> Eff (refs :: ReactRefs (write :: Write | access) | eff) Unit)
   -> Props
 refCb cb = unsafeMkProps "ref" (unsafePerformEff <<< cb)
 


### PR DESCRIPTION
* React.DOM.Props.ref - set ref property (string)
* React.readRef - read ref through Foreign

String refs are not yet deprecated, but they might be at some point and React-15.6.1 docs do not event mention them. Nevertheless we should support them.

I'd be keen to change `readRef` type to 
```
readRefs :: String -> Foreign -> Eff (refs :: ReactRef (read :: Read | access) | eff) (Either MultipleErrors Node)
```
i.e. 
 * run `runExcept`
 * use Foreign directly

This way it will be also use able if one sets a ref using a callback. Then on could pass `toForeigh this` and get back the ref.  Setting callback refs is not included in the patch but I'd be happy to find a solution for that - maybe with a more fresh mind in the morning :)