### PR TITLE
React 16

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "purescript-eff": "^3.0.0",
     "purescript-prelude": "^3.0.0",
-    "purescript-unsafe-coerce": "^3.0.0"
+    "purescript-unsafe-coerce": "^3.0.0",
+    "purescript-exceptions": "^3.1.0"
   },
   "devDependencies": {
     "purescript-console": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "purescript-react",
   "files": [],
   "peerDependencies": {
-    "react": "^15.6.1",
+    "react": "^16.0.0-alpha.13",
     "create-react-class": "^15.6.0"
   }
 }

--- a/src/React.js
+++ b/src/React.js
@@ -127,6 +127,21 @@ function createClass(toNullable, spec) {
 }
 exports["createClass'"] = createClass;
 
+function capitalize(s) {
+  if (!s)
+    return s;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+};
+
+function createClassStateless(dict) {
+  return function (f) {
+    if (!f.displayName)
+      f.displayName = capitalize(f.name);
+    return f;
+  };
+};
+exports.createClassStateless = createClassStateless;
+
 function forceUpdateCbImpl(this_, cb) {
   this_.forceUpdate(function() {
     return cb();

--- a/src/React.js
+++ b/src/React.js
@@ -84,7 +84,9 @@ function transformState(this_){
 }
 exports.transformState = transformState;
 
-function createClass(spec) {
+function createClass(toNullable, spec) {
+  var didCatch = toNullable(spec.componentDidCatch)
+
   var result = {
     displayName: spec.displayName,
     render: function(){
@@ -101,6 +103,9 @@ function createClass(spec) {
     componentDidMount: function(){
       return spec.componentDidMount(this)();
     },
+    componentDidCatch: didCatch
+      ? function(error, info) {return didCatch(this)(error)(info)(); }
+      : undefined,
     componentWillReceiveProps: function(nextProps){
       return spec.componentWillReceiveProps(this)(nextProps)();
     },
@@ -120,7 +125,7 @@ function createClass(spec) {
 
   return createReactClass(result);
 }
-exports.createClass = createClass;
+exports["createClass'"] = createClass;
 
 function handle(f) {
   return function(e){

--- a/src/React.purs
+++ b/src/React.purs
@@ -372,11 +372,17 @@ createClass :: forall props state render eff.
   ReactSpec props state render eff -> ReactClass props
 createClass spc = runFn2 createClass' toNullable spc
 
--- | Create a stateless React class.
-createClassStateless :: forall props render.
+-- | Create a stateless React class.  When using a non anonymous function the
+-- | displayName will be the capitalized name of the function, e.g.
+-- | ``` purescript
+-- | helloWorld = createClassStatelesss hellowWorldCls
+-- |    where
+-- |      hellowWorldCls props = ...
+-- | ```
+-- | Then the `displayName` will be set up to `HellowWorldCls`
+foreign import createClassStateless :: forall props render.
   ReactRender render =>
   (props -> render) -> ReactClass props
-createClassStateless = unsafeCoerce
 
 -- | Create a stateless React class with children access.
 createClassStateless' :: forall props render.

--- a/src/React.purs
+++ b/src/React.purs
@@ -156,6 +156,10 @@ instance reactElementReactRender :: ReactRender ReactElement
 
 instance stringReactRender :: ReactRender String
 
+instance intReactRender :: ReactRender Int
+
+instance numberReactRender :: ReactRender Number
+
 -- | A render function.
 type Render props state render eff =
   ReactThis props state ->

--- a/src/React.purs
+++ b/src/React.purs
@@ -333,13 +333,15 @@ foreign import createClass :: forall props state render eff.
   ReactSpec props state render eff -> ReactClass props
 
 -- | Create a stateless React class.
-createClassStateless :: forall props.
-  (props -> ReactElement) -> ReactClass props
+createClassStateless :: forall props render.
+  ReactRender render =>
+  (props -> render) -> ReactClass props
 createClassStateless = unsafeCoerce
 
 -- | Create a stateless React class with children access.
-createClassStateless' :: forall props.
-  (props -> Array ReactElement -> ReactElement) -> ReactClass props
+createClassStateless' :: forall props render.
+  ReactRender render =>
+  (props -> Array ReactElement -> render) -> ReactClass props
 createClassStateless' k =
   createClassStateless \props ->
     k props (childrenToArray (unsafeCoerce props).children)

--- a/src/React.purs
+++ b/src/React.purs
@@ -154,6 +154,8 @@ instance arrayReactRender :: ReactRender (Array ReactElement)
 
 instance reactElementReactRender :: ReactRender ReactElement
 
+instance stringReactRender :: ReactRender String
+
 -- | A render function.
 type Render props state render eff =
   ReactThis props state ->

--- a/src/React/DOM.purs
+++ b/src/React/DOM.purs
@@ -19,6 +19,12 @@ mkDOM dynamic tag props = createElement tag (unsafeFromPropsArray props)
 text :: String -> ReactElement
 text = unsafeCoerce
 
+int :: Int -> ReactElement
+int = unsafeCoerce
+
+number :: Number -> ReactElement
+number = unsafeCoerce
+
 a :: Array Props -> Array ReactElement -> ReactElement
 a = mkDOM (IsDynamic false) "a"
 


### PR DESCRIPTION
This solves #102. It may suffer from #105 if one is using props polymorphically, as in:
```
cls :: forall r. ReactRender r => ReactClass { r :: r }
cls = createClassStateless \{ r } -> r
```

it would be nice to have a warning in this case, but I think that's impossible. It would need to be shown only if one is passing `cls` to `createElement` directly but not if one is specialising the class. So it's ok to use the following `goodCls`:
```
goodCls :: ReactClass { r :: ReactElement }
goodCls = cls
```
but this leads to #105:
```
    -- somewhere in a render function
    render _  = pure $ createElement (cls :: ReactClass { r :: Array ReactElement }) { r: [] } []
```