### PR TITLE
Point documentation link to pursuit

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Low-level React Bindings for PureScript.
 
 For a more high-level set of bindings, you might like to look at `purescript-thermite`.
 
-- [Module Documentation](docs/)
+- [Module Documentation](https://pursuit.purescript.org/packages/purescript-react/)
 
 ```
 bower install purescript-react


### PR DESCRIPTION
There is no docs directory, link docs to Pursuit. Fix #89