### PR TITLE
Add the `foreignObject` SVG element

### DIFF
--- a/src/React/DOM/SVG.purs
+++ b/src/React/DOM/SVG.purs
@@ -28,6 +28,9 @@ ellipse = mkDOM (IsDynamic false) "ellipse"
 ellipse' :: Array ReactElement -> ReactElement
 ellipse' = ellipse []
 
+foreignObject :: Array Props -> Array ReactElement -> ReactElement
+foreignObject = mkDOM (IsDynamic false) "foreignObject"
+
 g :: Array Props -> Array ReactElement -> ReactElement
 g = mkDOM (IsDynamic false) "g"
 


### PR DESCRIPTION
I found myself needing this recently and added it locally at the time. I thought it was worth contributing.

Info on this element is available here: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/foreignObject