### PR TITLE
Add the SVG `x` and `y` attributes

### DIFF
--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -620,3 +620,10 @@ onWheel f = unsafeMkProps "onWheel" (handle f)
 
 suppressContentEditableWarning :: Boolean -> Props
 suppressContentEditableWarning = unsafeMkProps "suppressContentEditableWarning"
+
+-- SVG attributes
+x :: Int -> Props
+x = unsafeMkProps "x"
+
+y :: Int -> Props
+y = unsafeMkProps "y"


### PR DESCRIPTION
This relates to #112. It adds the SVG [x](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/x) and [y](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/y) attributes.

I wasn't sure if I should create a `React.DOM.SVG.Props` module instead.