### PR TITLE
Alternative class construction

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,9 @@
     "purescript-unsafe-coerce": "^3.0.0",
     "purescript-exceptions": "^3.1.0",
     "purescript-maybe": "^3.0.0",
-    "purescript-nullable": "^3.0.0"
+    "purescript-nullable": "^3.0.0",
+    "purescript-foreign": "^4.0.1",
+    "purescript-typelevel-prelude": "^2.5.0"
   },
   "devDependencies": {
     "purescript-console": "^3.0.0",

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,6 @@
     "purescript-exceptions": "^3.1.0",
     "purescript-maybe": "^3.0.0",
     "purescript-nullable": "^3.0.0",
-    "purescript-foreign": "^4.0.1",
     "purescript-typelevel-prelude": "^2.5.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "purescript-react",
   "files": [],
   "peerDependencies": {
-    "react": "^16.0.0",
-    "create-react-class": "^15.6.0"
+    "react": "^16.0.0"
   }
 }

--- a/src/React.js
+++ b/src/React.js
@@ -2,7 +2,56 @@
 "use strict";
 
 var React = require("react");
-var createReactClass = require("create-react-class");
+
+function createClass(baseClass) {
+  function bindProperty(instance, prop, value) {
+    switch (prop) {
+      case 'componentDidMount':
+      case 'componentDidUpdate':
+      case 'componentWillMount':
+      case 'componentWillUnmount':
+      case 'render':
+      case 'state':
+        instance[prop] = value;
+        break;
+
+      case 'componentWillReceiveProps':
+        instance[prop] = function (a) { return value(a)(); };
+        break;
+
+      case 'componentDidCatch':
+      case 'componentWillUpdate':
+      case 'shouldComponentUpdate':
+        instance[prop] = function (a, b) { return value(a)(b)(); };
+        break;
+
+      default:
+        throw new Error('Not a component property: ' + prop);
+    }
+  }
+
+  return function (displayName) {
+    return function (ctrFn) {
+      var Constructor = function (props) {
+        baseClass.call(this, props);
+        var spec = ctrFn(this)();
+        for (var k in spec) {
+          bindProperty(this, k, spec[k]);
+        }
+      };
+
+      Constructor.displayName = displayName;
+      Constructor.prototype = Object.create(baseClass.prototype);
+      Constructor.prototype.constructor = Constructor;
+
+      return Constructor;
+    };
+  };
+}
+
+exports.componentImpl = createClass(React.Component);
+
+exports.pureComponentImpl = createClass(React.PureComponent);
 
 function getProps(this_) {
   return function(){
@@ -10,13 +59,6 @@ function getProps(this_) {
   };
 }
 exports.getProps = getProps;
-
-function getRefs(this_) {
-  return function(){
-    return this_.refs;
-  };
-}
-exports.getRefs = getRefs;
 
 function childrenToArray(children) {
   var result = [];
@@ -40,33 +82,10 @@ function getChildren(this_) {
 }
 exports.getChildren = getChildren;
 
-function readRefImpl (this_) {
-  return function(name) {
-    return function() {
-      return this_[name];
-    }
-  }
-}
-exports.readRefImpl = readRefImpl;
-
-function writeRef(this_) {
-  return function(name) {
-    return function(node) {
-      return function() {
-        this_[name] = node;
-        return {};
-      }
-    }
-  }
-}
-exports.writeRef = writeRef;
-
 function writeState(this_) {
   return function(state){
     return function(){
-      this_.setState({
-        state: state
-      });
+      this_.setState(state);
       return state;
     };
   };
@@ -77,9 +96,7 @@ function writeStateWithCallback(this_, cb) {
   return function(state){
     return function(cb){
       return function() {
-        this_.setState({
-          state: state
-        }, cb);
+        this_.setState(state, cb);
         return state;
       };
     };
@@ -89,7 +106,7 @@ exports.writeStateWithCallback = writeStateWithCallback;
 
 function readState(this_) {
   return function(){
-    return this_.state.state;
+    return this_.state;
   };
 }
 exports.readState = readState;
@@ -98,70 +115,12 @@ function transformState(this_){
   return function(update){
     return function(){
       this_.setState(function(old, props){
-        return {state: update(old.state)};
+        return update(old);
       });
     };
   };
 }
 exports.transformState = transformState;
-
-function createClass(toNullable, spec) {
-  var didCatch = toNullable(spec.componentDidCatch)
-
-  var result = {
-    displayName: spec.displayName,
-    render: function(){
-      return spec.render(this)();
-    },
-    getInitialState: function(){
-      return {
-        state: spec.getInitialState(this)()
-      };
-    },
-    componentWillMount: function(){
-      return spec.componentWillMount(this)();
-    },
-    componentDidMount: function(){
-      return spec.componentDidMount(this)();
-    },
-    componentDidCatch: didCatch
-      ? function(error, info) {return didCatch(this)(error)(info)(); }
-      : undefined,
-    componentWillReceiveProps: function(nextProps){
-      return spec.componentWillReceiveProps(this)(nextProps)();
-    },
-    shouldComponentUpdate: function(nextProps, nextState){
-      return spec.shouldComponentUpdate(this)(nextProps)(nextState.state)();
-    },
-    componentWillUpdate: function(nextProps, nextState){
-      return spec.componentWillUpdate(this)(nextProps)(nextState.state)();
-    },
-    componentDidUpdate: function(prevProps, prevState){
-      return spec.componentDidUpdate(this)(prevProps)(prevState.state)();
-    },
-    componentWillUnmount: function(){
-      return spec.componentWillUnmount(this)();
-    }
-  };
-
-  return createReactClass(result);
-}
-exports["createClass'"] = createClass;
-
-function capitalize(s) {
-  if (!s)
-    return s;
-  return s.charAt(0).toUpperCase() + s.slice(1);
-};
-
-function createClassStateless(dict) {
-  return function (f) {
-    if (!f.displayName)
-      f.displayName = capitalize(f.name);
-    return f;
-  };
-};
-exports.createClassStateless = createClassStateless;
 
 function forceUpdateCbImpl(this_, cb) {
   this_.forceUpdate(function() {
@@ -197,11 +156,6 @@ function createElementDynamic(class_) {
 };
 exports.createElementDynamic = createElementDynamic;
 exports.createElementTagNameDynamic = createElementDynamic;
-
-function createFactory(class_) {
-  return React.createFactory(class_);
-}
-exports.createFactory = createFactory;
 
 function preventDefault(event) {
   return function() {

--- a/src/React.js
+++ b/src/React.js
@@ -60,27 +60,9 @@ function getProps(this_) {
 }
 exports.getProps = getProps;
 
-function childrenToArray(children) {
-  var result = [];
+exports.childrenToArray = React.Children.toArray
 
-  React.Children.forEach(children, function(child){
-    result.push(child);
-  });
-
-  return result;
-}
-exports.childrenToArray = childrenToArray;
-
-function getChildren(this_) {
-  return function(){
-    var children = this_.props.children;
-
-    var result = childrenToArray(children);
-
-    return result;
-  };
-}
-exports.getChildren = getChildren;
+exports.childrenCount = React.Children.count;
 
 function writeState(this_) {
   return function(state){
@@ -144,8 +126,15 @@ function createElement(class_) {
     };
   };
 }
-exports.createElement = createElement;
+exports.createElementImpl = createElement;
 exports.createElementTagName = createElement;
+
+function createLeafElement(class_) {
+  return function(props) {
+    return React.createElement(class_, props);
+  };
+}
+exports.createLeafElementImpl = createLeafElement;
 
 function createElementDynamic(class_) {
   return function(props) {
@@ -154,7 +143,7 @@ function createElementDynamic(class_) {
     };
   };
 };
-exports.createElementDynamic = createElementDynamic;
+exports.createElementDynamicImpl = createElementDynamic;
 exports.createElementTagNameDynamic = createElementDynamic;
 
 function preventDefault(event) {

--- a/src/React.js
+++ b/src/React.js
@@ -53,6 +53,8 @@ exports.componentImpl = createClass(React.Component);
 
 exports.pureComponentImpl = createClass(React.PureComponent);
 
+exports.statelessComponent = function(x) { return x; };
+
 function getProps(this_) {
   return function(){
     return this_.props;

--- a/src/React.purs
+++ b/src/React.purs
@@ -17,13 +17,8 @@ module React
 
   , ReactState
   , ReactProps
-  , ReactRefs
-
-  , Refs
-  , Ref
 
   , Render
-  , GetInitialState
   , ComponentWillMount
   , ComponentDidMount
   , ComponentDidCatch
@@ -33,7 +28,6 @@ module React
   , ComponentDidUpdate
   , ComponentWillUnmount
 
-  , ReactSpec
   , ReactClass
 
   , Event
@@ -42,12 +36,10 @@ module React
 
   , EventHandlerContext
 
-  , spec, spec'
+  , component
+  , pureComponent
 
   , getProps
-  , getRefs
-  , readRef
-  , writeRef
   , getChildren
 
   , readState
@@ -62,14 +54,10 @@ module React
   , preventDefault
   , stopPropagation
 
-  , createClass
-  , createClassStateless
-  , createClassStateless'
   , createElement
   , createElementDynamic
   , createElementTagName
   , createElementTagNameDynamic
-  , createFactory
 
   , Children
   , childrenToArray
@@ -79,11 +67,8 @@ import Prelude
 
 import Control.Monad.Eff (kind Effect, Eff)
 import Control.Monad.Eff.Exception (Error)
-import Data.Function.Uncurried (Fn2, runFn2)
-import Data.Maybe (Maybe(Nothing))
-import Data.Nullable (Nullable, toMaybe, toNullable)
 import Control.Monad.Eff.Uncurried (EffFn2, runEffFn2)
-import Unsafe.Coerce (unsafeCoerce)
+import Type.Row (class RowLacks)
 
 -- | Name of a tag.
 type TagName = String
@@ -123,14 +108,6 @@ foreign import data ReactState :: # Effect -> Effect
 -- | This effect indicates that a computation may read the component props.
 foreign import data ReactProps :: Effect
 
--- | This effect indicates that a computation may read the component refs.
--- |
--- | The first type argument is a row of access types (`Read`, `Write`).
-foreign import data ReactRefs :: # Effect -> Effect
-
--- | The type of refs objects.
-foreign import data Refs :: Type
-
 -- | The type of DOM events.
 foreign import data Event :: Type
 
@@ -159,7 +136,6 @@ type KeyboardEvent =
 type EventHandlerContext eff props state result =
   Eff
     ( props :: ReactProps
-    , refs :: ReactRefs ReadOnly
     , state :: ReactState ReadWrite
     | eff
     ) result
@@ -177,154 +153,158 @@ instance intReactRender :: ReactRender Int
 instance numberReactRender :: ReactRender Number
 
 -- | A render function.
-type Render props state render eff =
-  ReactThis props state ->
+type Render render eff =
   Eff
     ( props :: ReactProps
-    , refs :: ReactRefs Disallowed
     , state :: ReactState ReadOnly
     | eff
     ) render
 
--- | A get initial state function.
-type GetInitialState props state eff =
-  ReactThis props state ->
-  Eff
-    ( props :: ReactProps
-    , state :: ReactState Disallowed
-    , refs :: ReactRefs Disallowed
-    | eff
-    ) state
-
 -- | A component will mount function.
-type ComponentWillMount props state eff =
-  ReactThis props state ->
+type ComponentWillMount eff =
   Eff
     ( props :: ReactProps
     , state :: ReactState ReadWrite
-    , refs :: ReactRefs Disallowed
     | eff
     ) Unit
 
 -- | A component did mount function.
-type ComponentDidMount props state eff =
-  ReactThis props state ->
+type ComponentDidMount eff =
   Eff
     ( props :: ReactProps
     , state :: ReactState ReadWrite
-    , refs :: ReactRefs ReadOnly
     | eff
     ) Unit
 
-type ComponentDidCatch props state eff =
-  ReactThis props state ->
+type ComponentDidCatch eff =
   Error ->
   { componentStack :: String } ->
   Eff
     ( props :: ReactProps
     , state :: ReactState ReadWrite
-    , refs :: ReactRefs ReadOnly
     | eff
     ) Unit
 
-
 -- | A component will receive props function.
-type ComponentWillReceiveProps props state eff =
-   ReactThis props state ->
+type ComponentWillReceiveProps props eff =
    props ->
    Eff
     ( props :: ReactProps
     , state :: ReactState ReadWrite
-    , refs :: ReactRefs ReadOnly
     | eff
     ) Unit
 
 -- | A should component update function.
 type ShouldComponentUpdate props state eff =
-  ReactThis props state ->
   props ->
   state ->
   Eff
     ( props :: ReactProps
     , state :: ReactState ReadWrite
-    , refs :: ReactRefs ReadOnly
     | eff
     ) Boolean
 
 -- | A component will update function.
 type ComponentWillUpdate props state eff =
-  ReactThis props state ->
   props ->
   state ->
   Eff
     ( props :: ReactProps
     , state :: ReactState ReadWrite
-    , refs :: ReactRefs ReadOnly
     | eff
     ) Unit
 
 -- | A component did update function.
 type ComponentDidUpdate props state eff =
-  ReactThis props state ->
   props ->
   state ->
   Eff
     ( props :: ReactProps
     , state :: ReactState ReadOnly
-    , refs :: ReactRefs ReadOnly
     | eff
     ) Unit
 
 -- | A component will unmount function.
-type ComponentWillUnmount props state eff =
-  ReactThis props state ->
+type ComponentWillUnmount eff =
   Eff
     ( props :: ReactProps
     , state :: ReactState ReadOnly
-    , refs :: ReactRefs ReadOnly
     | eff
     ) Unit
 
--- | A specification of a component.
-type ReactSpec props state render eff =
-  { render :: Render props state render eff
-  , displayName :: String
-  , getInitialState :: GetInitialState props state eff
-  , componentWillMount :: ComponentWillMount props state eff
-  , componentDidMount :: ComponentDidMount props state eff
-  , componentDidCatch :: Maybe (ComponentDidCatch props state eff)
-  , componentWillReceiveProps :: ComponentWillReceiveProps props state eff
-  , shouldComponentUpdate :: ShouldComponentUpdate props state eff
+-- | Required fields for constructing a ReactClass.
+type ReactSpecRequired state render eff r =
+  ( state :: state
+  , render :: Render render eff
+  | r
+  )
+
+-- | Optional fields for constructing a ReactClass.
+type ReactSpecOptional props state eff r =
+  ( componentWillMount :: ComponentWillMount eff
+  , componentDidMount :: ComponentDidMount eff
+  , componentDidCatch :: ComponentDidCatch eff
+  , componentWillReceiveProps :: ComponentWillReceiveProps props eff
   , componentWillUpdate :: ComponentWillUpdate props state eff
   , componentDidUpdate :: ComponentDidUpdate props state eff
-  , componentWillUnmount :: ComponentWillUnmount props state eff
-  }
+  , componentWillUnmount :: ComponentWillUnmount eff
+  | r
+  )
 
--- | Create a component specification with a provided state.
-spec :: forall props state render eff.
-  ReactRender render =>
-  state -> Render props state render eff -> ReactSpec props state render eff
-spec state = spec' \_ -> pure state
+type ReactSpecShouldComponentUpdate props state eff =
+  ( shouldComponentUpdate :: ShouldComponentUpdate props state eff
+  )
 
--- | Create a component specification with a get initial state function.
-spec' :: forall props state render eff.
-  ReactRender render =>
-  GetInitialState props state eff ->
-  Render props state render eff ->
-  ReactSpec props state render eff
-spec' getInitialState renderFn =
-  { render: renderFn
-  , displayName: ""
-  , getInitialState: getInitialState
-  , componentWillMount: \_ -> pure unit
-  , componentDidMount: \_ -> pure unit
-  , componentDidCatch: Nothing
-  , componentWillReceiveProps: \_ _ -> pure unit
-  , shouldComponentUpdate: \_ _ _ -> pure true
-  , componentWillUpdate: \_ _ _ -> pure unit
-  , componentDidUpdate: \_ _ _ -> pure unit
-  , componentWillUnmount: \_ -> pure unit
-  }
+type ReactSpecAll props state render eff =
+  ReactSpecRequired state render eff (ReactSpecOptional props state eff (ReactSpecShouldComponentUpdate props state eff))
+
+type ReactSpecPure props state render eff =
+  ReactSpecRequired state render eff (ReactSpecOptional props state eff ())
+
+-- | The signature for a ReactClass constructor. A constructor takes the
+-- | `ReactThis` context and returns a record with appropriate lifecycle
+-- | methods.
+type ReactClassConstructor props state render eff r =
+  ReactThis props state ->
+  Eff
+    ( props :: ReactProps
+    , state :: ReactState Disallowed
+    | eff
+    ) (Record (ReactSpecRequired state render eff r))
+
+-- | Creates a `ReactClass`` inherited from `React.Component`.
+component
+  :: forall props state render eff r x
+   . Union (ReactSpecRequired (Record state) render eff r) x (ReactSpecAll (Record props) (Record state) render eff)
+  => RowLacks "children" props
+  => RowLacks "key" props
+  => ReactRender render
+  => String
+  -> ReactClassConstructor (Record props) (Record state) render eff r
+  -> ReactClass (Record props)
+component = componentImpl
+
+-- | Creates a `ReactClass`` inherited from `React.PureComponent`.
+pureComponent
+  :: forall props state render eff r x
+   . Union (ReactSpecRequired (Record state) render eff r) x (ReactSpecPure (Record props) (Record state) render eff)
+  => RowLacks "children" props
+  => RowLacks "key" props
+  => ReactRender render
+  => String
+  -> ReactClassConstructor (Record props) (Record state) render eff r
+  -> ReactClass (Record props)
+pureComponent = pureComponentImpl
+
+foreign import componentImpl :: forall this props eff r.
+  String ->
+  (this -> Eff eff r) ->
+  ReactClass props
+
+foreign import pureComponentImpl :: forall this props eff r.
+  String ->
+  (this -> Eff eff r) ->
+  ReactClass props
 
 -- | React class for components.
 foreign import data ReactClass :: Type -> Type
@@ -333,35 +313,6 @@ foreign import data ReactClass :: Type -> Type
 foreign import getProps :: forall props state eff.
   ReactThis props state ->
   Eff (props :: ReactProps | eff) props
-
--- | Read the component refs.
-foreign import getRefs :: forall props state access eff.
-  ReactThis props state ->
-  Eff (refs :: ReactRefs (read :: Read | access) | eff) Refs
-
--- | Ref type.  You can store `Ref` types on `Refs` object (which in
--- | corresponds to `this.refs`).  Use `ReactDOM.refToNode` if you want to
--- | store a `DOM.Node.Types.Node`
-foreign import data Ref :: Type
-
-foreign import readRefImpl :: forall props state access eff.
-  ReactThis props state ->
-  String ->
-  Eff (refs :: ReactRefs (read :: Read | access) | eff) (Nullable Ref)
-
--- | Read named ref from `Refs`.
-readRef :: forall props state access eff.
-  ReactThis props state ->
-  String ->
-  Eff (refs :: ReactRefs (read :: Read | access) | eff) (Maybe Ref)
-readRef this name = toMaybe <$> readRefImpl this name
-
--- | Write a `Ref` to `Refs`
-foreign import writeRef :: forall props state access eff.
-  ReactThis props state ->
-  String ->
-  Nullable Ref ->
-  Eff (refs :: ReactRefs (write :: Write | access) | eff) Unit
 
 -- | Read the component children property.
 foreign import getChildren :: forall props state eff.
@@ -375,7 +326,10 @@ foreign import writeState :: forall props state access eff.
   Eff (state :: ReactState (write :: Write | access) | eff) state
 
 -- | Write the component state with a callback.
-foreign import writeStateWithCallback :: forall props state access eff. ReactThis props state -> state -> Eff (state :: ReactState (write :: Write | access) | eff) Unit -> Eff (state :: ReactState (write :: Write | access) | eff) state
+foreign import writeStateWithCallback :: forall props state access eff.
+  ReactThis props state ->
+  state ->
+  Eff (state :: ReactState (write :: Write | access) | eff) Unit -> Eff (state :: ReactState (write :: Write | access) | eff) state
 
 -- | Read the component state.
 foreign import readState :: forall props state access eff.
@@ -387,37 +341,6 @@ foreign import transformState :: forall props state eff.
   ReactThis props state ->
   (state -> state) ->
   Eff (state :: ReactState ReadWrite | eff) Unit
-
--- | Create a React class from a specification.
-foreign import createClass' :: forall props state render eff.
-  Fn2
-    (forall a. Maybe a -> Nullable a)
-    (ReactSpec props state render eff)
-    (ReactClass props)
-
-createClass :: forall props state render eff.
-  ReactSpec props state render eff -> ReactClass props
-createClass spc = runFn2 createClass' toNullable spc
-
--- | Create a stateless React class.  When using a non anonymous function the
--- | displayName will be the capitalized name of the function, e.g.
--- | ``` purescript
--- | helloWorld = createClassStatelesss helloWorldCls
--- |    where
--- |      helloWorldCls props = ...
--- | ```
--- | Then the `displayName` will be set up to `HelloWorldCls`
-foreign import createClassStateless :: forall props render.
-  ReactRender render =>
-  (props -> render) -> ReactClass props
-
--- | Create a stateless React class with children access.
-createClassStateless' :: forall props render.
-  ReactRender render =>
-  (props -> Array ReactElement -> render) -> ReactClass props
-createClassStateless' k =
-  createClassStateless \props ->
-    k props (childrenToArray (unsafeCoerce props).children)
 
 -- | Force render of a react component.
 forceUpdate :: forall eff props state.
@@ -454,10 +377,6 @@ foreign import createElementTagName :: forall props.
 -- | Create an element from a tag name passing the children array. Used for a dynamic array of children.
 foreign import createElementTagNameDynamic :: forall props.
   TagName -> props -> Array ReactElement -> ReactElement
-
--- | Create a factory from a React class.
-foreign import createFactory :: forall props.
-  ReactClass props -> props -> ReactElement
 
 -- | Internal representation for the children elements passed to a component
 foreign import data Children :: Type

--- a/src/React.purs
+++ b/src/React.purs
@@ -72,6 +72,7 @@ import Prelude
 import Control.Monad.Eff (kind Effect, Eff)
 import Control.Monad.Eff.Exception (Error)
 import Control.Monad.Eff.Uncurried (EffFn2, runEffFn2)
+import Data.Nullable (Nullable)
 
 -- | Name of a tag.
 type TagName = String
@@ -362,9 +363,15 @@ foreign import handle :: forall eff ev props state result.
 
 class ReactPropFields (required :: # Type) (given :: # Type)
 
+type ReservedReactPropFields r =
+  ( key :: String
+  , ref :: EventHandler (Nullable Ref)
+  | r
+  )
+
 instance reactPropFields ::
-  ( Union given optional (key :: String | required)
-  , Union optional leftover (key :: String)
+  ( Union given optional (ReservedReactPropFields required)
+  , Union optional leftover (ReservedReactPropFields ())
   ) =>
   ReactPropFields required given
 

--- a/src/React.purs
+++ b/src/React.purs
@@ -39,6 +39,7 @@ module React
 
   , component
   , pureComponent
+  , statelessComponent
 
   , getProps
 
@@ -305,6 +306,10 @@ foreign import pureComponentImpl :: forall this props eff r.
   String ->
   (this -> Eff eff r) ->
   ReactClass props
+
+foreign import statelessComponent :: forall props.
+  (Record props -> ReactElement) ->
+  ReactClass (Record props)
 
 -- | React class for components.
 foreign import data ReactClass :: Type -> Type

--- a/src/React.purs
+++ b/src/React.purs
@@ -29,6 +29,7 @@ module React
   , ComponentWillUnmount
 
   , ReactClass
+  , Ref
 
   , Event
   , MouseEvent
@@ -308,6 +309,10 @@ foreign import pureComponentImpl :: forall this props eff r.
 
 -- | React class for components.
 foreign import data ReactClass :: Type -> Type
+
+-- | Type for React refs. This type is opaque, but you can use `Data.Foreign`
+-- | and `DOM` to validate the underlying representation.
+foreign import data Ref :: Type
 
 -- | Read the component props.
 foreign import getProps :: forall props state eff.

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -1,10 +1,8 @@
 module React.DOM.Props where
 
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Unsafe (unsafePerformEff)
+import Data.Foreign (Foreign)
 import Data.Nullable (Nullable)
-import Prelude (Unit, (<<<))
-import React (Event, EventHandlerContext, KeyboardEvent, MouseEvent, ReactRefs, Ref, Write, handle)
+import React (Event, EventHandlerContext, KeyboardEvent, MouseEvent, handle)
 
 foreign import data Props :: Type
 
@@ -300,22 +298,6 @@ radioGroup = unsafeMkProps "radioGroup"
 
 readOnly :: Boolean -> Props
 readOnly = unsafeMkProps "readOnly"
-
--- | You can use `ref` to store a reference on `this.refs`.
--- | To access the stored reference, `getRefs` can then be used.
-ref :: String -> Props
-ref = unsafeMkProps "ref"
-
--- | You can use `writeRef` to store a reference on `this`.
--- | ```purescript
--- | div [ withRef (writeRef this "inputElement") ] [...]
--- | ```
--- | To access the stored reference, `readRef` can then be used.
-withRef
-  :: forall access eff
-   . (Nullable Ref -> Eff (refs :: ReactRefs (write :: Write | access) | eff) Unit)
-  -> Props
-withRef cb = unsafeMkProps "ref" (unsafePerformEff <<< cb)
 
 rel :: String -> Props
 rel = unsafeMkProps "rel"
@@ -637,6 +619,10 @@ onScroll f = unsafeMkProps "onScroll" (handle f)
 onWheel :: forall eff props state result.
   (Event -> EventHandlerContext eff props state result) -> Props
 onWheel f = unsafeMkProps "onWheel" (handle f)
+
+ref :: forall eff props state result.
+  (Nullable Foreign -> EventHandlerContext eff props state result) -> Props
+ref f = unsafeMkProps "ref" (handle f)
 
 suppressContentEditableWarning :: Boolean -> Props
 suppressContentEditableWarning = unsafeMkProps "suppressContentEditableWarning"

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -1,8 +1,7 @@
 module React.DOM.Props where
 
-import Data.Foreign (Foreign)
 import Data.Nullable (Nullable)
-import React (Event, EventHandlerContext, KeyboardEvent, MouseEvent, handle)
+import React (Event, EventHandlerContext, KeyboardEvent, MouseEvent, Ref, handle)
 
 foreign import data Props :: Type
 
@@ -621,7 +620,7 @@ onWheel :: forall eff props state result.
 onWheel f = unsafeMkProps "onWheel" (handle f)
 
 ref :: forall eff props state result.
-  (Nullable Foreign -> EventHandlerContext eff props state result) -> Props
+  (Nullable Ref -> EventHandlerContext eff props state result) -> Props
 ref f = unsafeMkProps "ref" (handle f)
 
 suppressContentEditableWarning :: Boolean -> Props


### PR DESCRIPTION
This removes `createClass` and `spec` as well as the dependency on
`create-react-class` in favor of `component` and `pureComponent` which
creates constructors that inherit from `React.Component` and
`React.PureComponent` in an idiomatic way for React. This also obviates
the need for some machinery like `ref` handling, which can be
implemented with `purescript-refs` instead.