### PR TITLE
Support value property for multiselect

### DIFF
--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -407,6 +407,9 @@ useMap = unsafeMkProps "useMap"
 value :: String -> Props
 value = unsafeMkProps "value"
 
+value' :: Array String -> Props
+value' = unsafeMkProps "value"
+
 width :: String -> Props
 width = unsafeMkProps "width"
 

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -407,8 +407,8 @@ useMap = unsafeMkProps "useMap"
 value :: String -> Props
 value = unsafeMkProps "value"
 
-value' :: Array String -> Props
-value' = unsafeMkProps "value"
+valueArray :: Array String -> Props
+valueArray = unsafeMkProps "value"
 
 width :: String -> Props
 width = unsafeMkProps "width"


### PR DESCRIPTION
React warns when using `selected` for `option`. They recommend to use `value` for `select`.
But when `select` is `multiple` it's impossible to pass array of values:
```purescript
value :: String -> Props
```
In latest version of React `selected` for several `option` won't work.

In JSX/JavaScript it's possible to send value as string and array:
```jsx
<select value={'A'}>
<select multiple={true} value={['B', 'C']}>
```
https://reactjs.org/docs/forms.html#the-select-tag