### PR TITLE
add transformStateWithCallback

### DIFF
--- a/src/React.js
+++ b/src/React.js
@@ -108,6 +108,19 @@ function transformState(this_){
 }
 exports.transformState = transformState;
 
+function transformStateWithCallback(this_){
+  return function(update){
+    return function(cb){
+      return function(){
+        this_.setState(function(old, props){
+          return update(old);
+        }, cb);
+      };
+    };
+  };
+}
+exports.transformStateWithCallback = transformStateWithCallback;
+
 function forceUpdateCbImpl(this_, cb) {
   this_.forceUpdate(function() {
     return cb();

--- a/src/React.purs
+++ b/src/React.purs
@@ -37,6 +37,7 @@ module React
   , writeState
   , writeStateWithCallback
   , transformState
+  , transformStateWithCallback
 
   , forceUpdate
   , forceUpdateCb
@@ -308,6 +309,13 @@ foreign import readState :: forall props state access eff.
 foreign import transformState :: forall props state eff.
   ReactThis props state ->
   (state -> state) ->
+  Eff (state :: ReactState ReadWrite | eff) Unit
+
+-- | Transform the component state by applying a function with a callback.
+foreign import transformStateWithCallback :: forall props state eff.
+  ReactThis props state ->
+  (state -> state) ->
+  Eff (state :: ReactState ReadWrite | eff) Unit ->
   Eff (state :: ReactState ReadWrite | eff) Unit
 
 -- | Force render of a react component.


### PR DESCRIPTION
Similar to `writeStateWithCallback`, since mutated state is not immediately available after calling `transformState`.