### PR TITLE
Better Documentation, subtle typos and syntactic details

### DIFF
--- a/src/React.js
+++ b/src/React.js
@@ -65,7 +65,7 @@ function createClassWithDerivedState(classCtr) {
     return function(getDerivedStateFromProps) {
       return function(ctrFn) {
         var Constructor = componentImpl(displayName)(ctrFn);
-        Constructor.getDerivedStateFromProps = function(a, b) { return getDerivedStateFromProps(a)(b) };
+        Constructor.getDerivedStateFromProps = function(a, b) { return getDerivedStateFromProps(a)(b); };
         return Constructor;
       };
     };
@@ -77,7 +77,7 @@ exports.componentImpl = componentImpl;
 exports.componentWithDerivedStateImpl = createClassWithDerivedState(componentImpl);
 
 var pureComponentImpl = createClass(React.PureComponent);
-exports.pureComponentImpl = pureComponentImpl
+exports.pureComponentImpl = pureComponentImpl;
 exports.pureComponentWithDerivedStateImpl = createClassWithDerivedState(pureComponentImpl);
 
 exports.statelessComponent = function(x) { return x; };
@@ -91,7 +91,7 @@ function getProps(this_) {
 }
 exports.getProps = getProps;
 
-exports.childrenToArray = React.Children.toArray
+exports.childrenToArray = React.Children.toArray;
 
 exports.childrenCount = React.Children.count;
 

--- a/src/React.purs
+++ b/src/React.purs
@@ -58,6 +58,7 @@ module React
   , childrenCount
   , class IsReactElement
   , toElement
+  , fragment
   , fragmentWithKey
   , Context
   , ContextProvider
@@ -186,7 +187,7 @@ instance reactPureComponentSpec ::
   ) =>
   ReactPureComponentSpec props state snapshot given spec
 
--- | Creates a `ReactClass`` inherited from `React.Component`.
+-- | Creates a `ReactClass` inherited from `React.Component`.
 component :: forall props state snapshot given spec.
   ReactComponentSpec (Record props) (Record state) snapshot given spec =>
   String ->
@@ -203,7 +204,7 @@ componentWithDerivedState :: forall props state snapshot given spec.
   ReactClass (Record props)
 componentWithDerivedState = componentWithDerivedStateImpl
 
--- | Creates a `ReactClass`` inherited from `React.PureComponent`.
+-- | Creates a `ReactClass` inherited from `React.PureComponent`.
 pureComponent :: forall props state snapshot given spec.
   ReactPureComponentSpec (Record props) (Record state) snapshot given spec =>
   String ->
@@ -391,7 +392,9 @@ foreign import createElementImpl :: forall required given children.
 foreign import createElementDynamicImpl :: forall required given children.
   ReactClass required -> given -> Array children -> ReactElement
 
--- | Create an element from a React class that does not require children.
+-- | Create an element from a React class that does not require children. Additionally it can be used
+-- | when the children are represented /only/ through the `children` prop - for instance, a `ContextConsumer`
+-- | would be turned into a `ReactElement` with `createLeafElement someContext.consumer { children = \x -> ... }`.
 createLeafElement :: forall required given.
   ReactPropFields required given =>
   ReactClass { | required } ->

--- a/src/React.purs
+++ b/src/React.purs
@@ -394,7 +394,7 @@ foreign import createElementDynamicImpl :: forall required given children.
 
 -- | Create an element from a React class that does not require children. Additionally it can be used
 -- | when the children are represented /only/ through the `children` prop - for instance, a `ContextConsumer`
--- | would be turned into a `ReactElement` with `createLeafElement someContext.consumer { children = \x -> ... }`.
+-- | would be turned into a `ReactElement` with `createLeafElement someContext.consumer { children: \x -> ... }`.
 createLeafElement :: forall required given.
   ReactPropFields required given =>
   ReactClass { | required } ->


### PR DESCRIPTION
There is some additional prose I wrote in README that should probably be reviewed to ensure it explains the concept correctly. I've also added an additional detail to the `createLeafNode` inline documentation.

There are a couple of semicolons I've added to the `React.js` foreign interface, but nothing invasive.

I've also exposed the `fragment` ReactClass in `React.purs`, for people who don't necessarily want a keyed fragment.

There were also a few typos in other parts of the inline documentation, with the troublesome double-tick ``` `` ```.