### PR TITLE
Add support for `createRef` API

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,8 @@
     "purescript-exceptions": "^4.0.0",
     "purescript-maybe": "^4.0.0",
     "purescript-nullable": "^4.0.0",
-    "purescript-typelevel-prelude": ">= 4.0.0 < 6.0.0"
+    "purescript-typelevel-prelude": ">= 4.0.0 < 6.0.0",
+    "purescript-web-html": "^2.2.0"
   },
   "devDependencies": {
     "purescript-console": "^4.1.0",

--- a/bower.json
+++ b/bower.json
@@ -23,8 +23,7 @@
     "purescript-exceptions": "^4.0.0",
     "purescript-maybe": "^4.0.0",
     "purescript-nullable": "^4.0.0",
-    "purescript-typelevel-prelude": ">= 4.0.0 < 6.0.0",
-    "purescript-web-html": "^2.2.0"
+    "purescript-typelevel-prelude": ">= 4.0.0 < 6.0.0"
   },
   "devDependencies": {
     "purescript-console": "^4.1.0",

--- a/src/React.purs
+++ b/src/React.purs
@@ -32,7 +32,6 @@ module React
   , pureComponentWithDerivedState
   , statelessComponent
   , ReactClass
-  , ReactRef
   , getProps
   , getState
   , setState
@@ -68,13 +67,14 @@ module React
 
 import Prelude
 
-import Data.Nullable (Nullable)
+-- import Data.Nullable (Nullable)
 import Effect (Effect)
 import Effect.Exception (Error)
 import Effect.Uncurried (EffectFn1)
 import Prim.Row as Row
 import Type.Row (type (+))
 import Unsafe.Coerce (unsafeCoerce)
+import React.Ref as Ref
 
 -- | Name of a tag.
 type TagName = String
@@ -252,10 +252,6 @@ foreign import data ReactClass :: Type -> Type
 
 foreign import fragment :: ReactClass { children :: Children }
 
--- | Type for React refs. This type is opaque, but you can use `Data.Foreign`
--- | and `DOM` to validate the underlying representation.
-foreign import data ReactRef :: Type
-
 -- | Read the component props.
 foreign import getProps :: forall props state.
   ReactThis props state ->
@@ -340,7 +336,7 @@ class ReactPropFields (required :: # Type) (given :: # Type)
 
 type ReservedReactPropFields r =
   ( key :: String
-  , ref :: SyntheticEventHandler (Nullable ReactRef)
+  , ref :: Ref.RefHandler Ref.ReactInstance
   | r
   )
 

--- a/src/React.purs
+++ b/src/React.purs
@@ -67,14 +67,13 @@ module React
 
 import Prelude
 
--- import Data.Nullable (Nullable)
 import Effect (Effect)
 import Effect.Exception (Error)
 import Effect.Uncurried (EffectFn1)
 import Prim.Row as Row
+import React.Ref as Ref
 import Type.Row (type (+))
 import Unsafe.Coerce (unsafeCoerce)
-import React.Ref as Ref
 
 -- | Name of a tag.
 type TagName = String

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -2,10 +2,11 @@ module React.DOM.Props where
 
 import Prelude
 
-import Data.Nullable (Nullable)
+import Web.HTML.HTMLElement (HTMLElement)
+-- import Data.Nullable (Nullable)
 import Effect (Effect)
 import Effect.Uncurried (mkEffectFn1)
-import React (ReactRef)
+import React.Ref as Ref
 import React.SyntheticEvent
   ( SyntheticEvent
   , SyntheticAnimationEvent
@@ -894,8 +895,8 @@ onScrollCapture f = unsafeMkProps "onScrollCapture" (mkEffectFn1 f)
 onWheelCapture :: (SyntheticWheelEvent -> Effect Unit) -> Props
 onWheelCapture f = unsafeMkProps "onWheelCapture" (mkEffectFn1 f)
 
-ref :: (Nullable ReactRef -> Effect Unit) -> Props
-ref f = unsafeMkProps "ref" (mkEffectFn1 f)
+ref :: Ref.RefHandler HTMLElement -> Props
+ref = unsafeMkProps "ref"
 
 suppressContentEditableWarning :: Boolean -> Props
 suppressContentEditableWarning = unsafeMkProps "suppressContentEditableWarning"

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -19,7 +19,6 @@ import React.SyntheticEvent
   , SyntheticUIEvent
   , SyntheticWheelEvent
   )
-import Web.HTML.HTMLElement (HTMLElement)
 
 foreign import data Props :: Type
 

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -2,8 +2,6 @@ module React.DOM.Props where
 
 import Prelude
 
-import Web.HTML.HTMLElement (HTMLElement)
--- import Data.Nullable (Nullable)
 import Effect (Effect)
 import Effect.Uncurried (mkEffectFn1)
 import React.Ref as Ref
@@ -21,6 +19,7 @@ import React.SyntheticEvent
   , SyntheticUIEvent
   , SyntheticWheelEvent
   )
+import Web.HTML.HTMLElement (HTMLElement)
 
 foreign import data Props :: Type
 

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -894,7 +894,7 @@ onScrollCapture f = unsafeMkProps "onScrollCapture" (mkEffectFn1 f)
 onWheelCapture :: (SyntheticWheelEvent -> Effect Unit) -> Props
 onWheelCapture f = unsafeMkProps "onWheelCapture" (mkEffectFn1 f)
 
-ref :: Ref.RefHandler HTMLElement -> Props
+ref :: Ref.RefHandler Ref.NativeNode -> Props
 ref = unsafeMkProps "ref"
 
 suppressContentEditableWarning :: Boolean -> Props

--- a/src/React/Ref.js
+++ b/src/React/Ref.js
@@ -1,0 +1,10 @@
+"use strict";
+
+var React = require("react");
+
+exports.createRef = React.createRef;
+
+exports.getCurrentRef_ = function(ref) {
+  if (ref.current) return ref.current;
+  else return ref;
+}

--- a/src/React/Ref.js
+++ b/src/React/Ref.js
@@ -4,7 +4,10 @@ var React = require("react");
 
 exports.createRef = React.createRef;
 
+exports.liftCallbackRef = function(ref) {
+  return { current: ref };
+}
+
 exports.getCurrentRef_ = function(ref) {
-  if (ref.hasOwnProperty('current')) return ref.current;
-  else return ref;
+  return ref.current;
 }

--- a/src/React/Ref.js
+++ b/src/React/Ref.js
@@ -5,6 +5,6 @@ var React = require("react");
 exports.createRef = React.createRef;
 
 exports.getCurrentRef_ = function(ref) {
-  if (ref.current) return ref.current;
+  if (ref.hasOwnProperty('current')) return ref.current;
   else return ref;
 }

--- a/src/React/Ref.purs
+++ b/src/React/Ref.purs
@@ -2,6 +2,7 @@ module React.Ref
   ( Ref
   , RefHandler
   , ReactInstance
+  , NativeNode
   , fromRef
   , fromEffect
   , getCurrentRef
@@ -12,7 +13,6 @@ module React.Ref
 import Prelude
 import Effect (Effect)
 import Data.Maybe (Maybe)
-import Web.HTML.HTMLElement (HTMLElement)
 import Data.Nullable (Nullable)
 import Data.Nullable as Nullable
 import Effect.Uncurried (EffectFn1, runEffectFn1, mkEffectFn1)
@@ -21,6 +21,8 @@ import Unsafe.Coerce (unsafeCoerce)
 
 foreign import data ReactInstance :: Type
 
+foreign import data NativeNode :: Type
+
 foreign import data Ref :: Type -> Type
 
 foreign import data RefHandler :: Type -> Type
@@ -28,7 +30,7 @@ foreign import data RefHandler :: Type -> Type
 
 foreign import createRef :: forall a. Effect (Ref a)
 
-createDOMRef :: Effect (Ref HTMLElement)
+createDOMRef :: Effect (Ref NativeNode)
 createDOMRef = createRef
 
 createInstanceRef :: Effect (Ref ReactInstance)

--- a/src/React/Ref.purs
+++ b/src/React/Ref.purs
@@ -30,8 +30,12 @@ foreign import data RefHandler :: Type -> Type
 
 foreign import createRef :: forall a. Effect (Ref a)
 
+foreign import liftCallbackRef :: forall a. Ref a -> Ref a
+
+
 createDOMRef :: Effect (Ref NativeNode)
 createDOMRef = createRef
+
 
 createInstanceRef :: Effect (Ref ReactInstance)
 createInstanceRef = createRef
@@ -42,7 +46,7 @@ fromRef = unsafeCoerce
 
 
 fromEffect :: forall a. (Ref a -> Effect Unit) -> RefHandler a
-fromEffect = unsafeCoerce <<< mkEffectFn1
+fromEffect f = unsafeCoerce $ mkEffectFn1 (f <<< liftCallbackRef)
 
 
 foreign import getCurrentRef_ :: forall a. EffectFn1 (Ref a) (Nullable a)

--- a/src/React/Ref.purs
+++ b/src/React/Ref.purs
@@ -6,7 +6,7 @@ module React.Ref
   , fromRef
   , fromEffect
   , getCurrentRef
-  , createDOMRef
+  , createNodeRef
   , createInstanceRef
   ) where
 
@@ -35,8 +35,8 @@ foreign import createRef :: forall a. Effect (Ref a)
 foreign import liftCallbackRef :: forall a. Ref a -> Ref a
 
 
-createDOMRef :: Effect (Ref NativeNode)
-createDOMRef = createRef
+createNodeRef :: Effect (Ref NativeNode)
+createNodeRef = createRef
 
 
 createInstanceRef :: Effect (Ref ReactInstance)

--- a/src/React/Ref.purs
+++ b/src/React/Ref.purs
@@ -1,0 +1,49 @@
+module React.Ref
+  ( Ref
+  , RefHandler
+  , ReactInstance
+  , fromRef
+  , fromEffect
+  , getCurrentRef
+  , createDOMRef
+  , createInstanceRef
+  ) where
+
+import Prelude
+import Effect (Effect)
+import Data.Maybe (Maybe)
+import Web.HTML.HTMLElement (HTMLElement)
+import Data.Nullable (Nullable)
+import Data.Nullable as Nullable
+import Effect.Uncurried (EffectFn1, runEffectFn1, mkEffectFn1)
+import Unsafe.Coerce (unsafeCoerce)
+
+
+foreign import data ReactInstance :: Type
+
+foreign import data Ref :: Type -> Type
+
+foreign import data RefHandler :: Type -> Type
+
+
+foreign import createRef :: forall a. Effect (Ref a)
+
+createDOMRef :: Effect (Ref HTMLElement)
+createDOMRef = createRef
+
+createInstanceRef :: Effect (Ref ReactInstance)
+createInstanceRef = createRef
+
+
+fromRef :: forall a. Ref a -> RefHandler a
+fromRef = unsafeCoerce
+
+
+fromEffect :: forall a. (Ref a -> Effect Unit) -> RefHandler a
+fromEffect = unsafeCoerce <<< mkEffectFn1
+
+
+foreign import getCurrentRef_ :: forall a. EffectFn1 (Ref a) (Nullable a)
+
+getCurrentRef :: forall a. Ref a -> Effect (Maybe a)
+getCurrentRef ref = Nullable.toMaybe <$> runEffectFn1 getCurrentRef_ ref

--- a/src/React/Ref.purs
+++ b/src/React/Ref.purs
@@ -18,9 +18,11 @@ import Data.Nullable as Nullable
 import Effect.Uncurried (EffectFn1, runEffectFn1, mkEffectFn1)
 import Unsafe.Coerce (unsafeCoerce)
 
-
+--- | An instance of a React class.
 foreign import data ReactInstance :: Type
 
+--- | A platform-specific native layout node. On the web this will be a DOM
+--- | element (see `Web.HTML.HTMLElement`).
 foreign import data NativeNode :: Type
 
 foreign import data Ref :: Type -> Type


### PR DESCRIPTION
Fixes #167 by adding support for React's `createRef` API. Also distinguishes between DOM refs and React instance refs.

I've created a [branch of `purescript-react-example`](https://github.com/elliotdavies/purescript-react-example/tree/refs) to showcase the different combinations of props, callbacks and ref types (see [here](https://github.com/elliotdavies/purescript-react-example/blob/refs/src/Main.purs#L109) in particular).

----

The `ReactInstance` type probably isn't in the right place; I can move it somewhere else. (`React.purs` feels better but that causes an import cycle.)

~Otherwise the only thing I dislike is having to check `ref.current` to see whether the item is a ref, or an object with the shape `{ current: <ref> }` (see https://reactjs.org/docs/refs-and-the-dom.html#accessing-refs). I'm not sure I see a way around this, though.~