### PR TITLE
Update related modules and installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,12 @@
 [![Maintainer: ethul](https://img.shields.io/badge/maintainer-ethul-lightgrey.svg)](http://github.com/ethul)
 ![React: 16](https://img.shields.io/badge/react-16-lightgrey.svg)
 
-Low-level React Bindings for PureScript.
-
-For a more high-level set of bindings, you might like to look at `purescript-thermite`.
+Low-level React bindings for PureScript. For a more high-level set of bindings, you might like to look at [`purescript-react-basic`](https://github.com/lumihq/purescript-react-basic).
 
 - [Module Documentation](https://pursuit.purescript.org/packages/purescript-react/)
 
-```
-bower install purescript-react
+```sh
+spago install react
 ```
 
 This library requires the `react` module. This dependency may be satisfied by installing the NPM [react package](https://www.npmjs.com/package/react).
@@ -22,7 +20,6 @@ npm install react
 ## Related Modules
 
 - [React DOM](https://github.com/purescript-contrib/purescript-react-dom)
-- [CSS Transition Group Addon](https://github.com/purescript-contrib/purescript-react-addons-css-transition-group)
 
 ## Example
 


### PR DESCRIPTION
The community has largely coalesced around `purescript-react-basic` as a high-level React library (as opposed to `purescript-thermite`, which saw most of its development pre-2017) and around Spago as a package manager (as opposed to Bower). This patch updates the README to point folks in the direction that is most commonly recommended on Slack, Discourse, etc.

The CSS Transition Group module has been deprecated so I removed it from the README.