### PR TITLE
Add roles declarations to allow safe coercions

### DIFF
--- a/src/React.purs
+++ b/src/React.purs
@@ -93,6 +93,8 @@ foreign import data ReactComponent :: Type
 -- | A reference to a component, essentially React's `this`.
 foreign import data ReactThis :: Type -> Type -> Type
 
+type role ReactThis representational representational
+
 foreign import data ReactUnusedSnapshot :: Type
 
 type SyntheticEventHandler event = EffectFn1 event Unit
@@ -250,6 +252,8 @@ foreign import statelessComponent :: forall props.
 
 -- | React class for components.
 foreign import data ReactClass :: Type -> Type
+
+type role ReactClass representational
 
 foreign import fragment :: ReactClass { children :: Children }
 

--- a/src/React/Ref.purs
+++ b/src/React/Ref.purs
@@ -27,7 +27,11 @@ foreign import data NativeNode :: Type
 
 foreign import data Ref :: Type -> Type
 
+type role Ref representational
+
 foreign import data RefHandler :: Type -> Type
+
+type role RefHandler representational
 
 
 foreign import createRef :: forall a. Effect (Ref a)

--- a/src/React/SyntheticEvent.purs
+++ b/src/React/SyntheticEvent.purs
@@ -136,6 +136,8 @@ type SyntheticWheelEvent
 
 foreign import data SyntheticEvent_ :: Row Type -> Type
 
+type role SyntheticEvent_ representational
+
 foreign import data NativeEventTarget :: Type
 
 foreign import data NativeEvent :: Type


### PR DESCRIPTION
This allows terms of type `ReactThis props state`, `ReactClass props`, `Ref a`, `RefHandler a` and `SyntheticEvent_ event` to be coerced to type `ReactThis props' state'`, `ReactClass props'`, `Ref b`, `RefHandler b` and `SyntheticEvent_ event'` when `Coercible props props'`, `Coercible state state'`, `Coercible a b` and `Coercible event event'` hold, hence allowing the zero cost `coerce` to introduce and eliminate newtypes in components props and state, refs and their handlers and synthetic events for instance.