### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -25,9 +27,9 @@ jobs:
             output
 
       - name: Set up Node toolchain
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache NPM dependencies
         uses: actions/cache@v2
@@ -49,3 +51,6 @@ jobs:
 
       - name: Run tests
         run: npm run test
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 !.eslintrc.json
 
 output

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#182 by @thomashoneyman)
 
 ## [v9.0.0](https://github.com/purescript-contrib/purescript-react/releases/tag/v9.0.0) - 2021-02-26
 

--- a/src/React.purs
+++ b/src/React.purs
@@ -156,21 +156,19 @@ type ReactSpecShouldComponentUpdate props state =
   ( shouldComponentUpdate :: ShouldComponentUpdate props state
   )
 
-type ReactSpecAll props state snapshot
-  = ReactSpecRequired state
-  + ReactSpecOptional props state snapshot
-  + ReactSpecShouldComponentUpdate props state
+type ReactSpecAll props state snapshot =
+  ReactSpecRequired state
+    + ReactSpecOptional props state snapshot
+    + ReactSpecShouldComponentUpdate props state
 
-type ReactSpecPure props state snapshot
-  = ReactSpecRequired state
-  + ReactSpecOptional props state snapshot ()
+type ReactSpecPure props state snapshot =
+  ReactSpecRequired state
+    + ReactSpecOptional props state snapshot ()
 
 -- | The signature for a ReactClass constructor. A constructor takes the
 -- | `ReactThis` context and returns a record with appropriate lifecycle
 -- | methods.
-type ReactClassConstructor props state r =
-  ReactThis props state
-  -> Effect (Record r)
+type ReactClassConstructor props state r = ReactThis props state -> Effect (Record r)
 
 class ReactComponentSpec :: Type -> Type -> Type -> Row Type -> Row Type -> Constraint
 class ReactComponentSpec props state snapshot (given :: Row Type) (spec :: Row Type)

--- a/src/React.purs
+++ b/src/React.purs
@@ -169,8 +169,8 @@ type ReactSpecPure props state snapshot
 -- | `ReactThis` context and returns a record with appropriate lifecycle
 -- | methods.
 type ReactClassConstructor props state r =
-  ReactThis props state ->
-  Effect (Record r)
+  ReactThis props state
+  -> Effect (Record r)
 
 class ReactComponentSpec :: Type -> Type -> Type -> Row Type -> Row Type -> Constraint
 class ReactComponentSpec props state snapshot (given :: Row Type) (spec :: Row Type)
@@ -191,64 +191,73 @@ instance reactPureComponentSpec ::
   ReactPureComponentSpec props state snapshot given spec
 
 -- | Creates a `ReactClass` inherited from `React.Component`.
-component :: forall props state snapshot given spec.
-  ReactComponentSpec (Record props) (Record state) snapshot given spec =>
-  String ->
-  ReactClassConstructor (Record props) (Record state) given ->
-  ReactClass (Record props)
+component
+  :: forall props state snapshot given spec
+   . ReactComponentSpec (Record props) (Record state) snapshot given spec
+  => String
+  -> ReactClassConstructor (Record props) (Record state) given
+  -> ReactClass (Record props)
 component = componentImpl
 
 -- | Like `component`, but takes a `getDerivedStateFromProps` handler.
-componentWithDerivedState :: forall props state snapshot given spec.
-  ReactComponentSpec (Record props) (Record state) snapshot given spec =>
-  String ->
-  (Record props -> Record state -> Record state) ->
-  ReactClassConstructor (Record props) (Record state) given ->
-  ReactClass (Record props)
+componentWithDerivedState
+  :: forall props state snapshot given spec
+   . ReactComponentSpec (Record props) (Record state) snapshot given spec
+  => String
+  -> (Record props -> Record state -> Record state)
+  -> ReactClassConstructor (Record props) (Record state) given
+  -> ReactClass (Record props)
 componentWithDerivedState = componentWithDerivedStateImpl
 
 -- | Creates a `ReactClass` inherited from `React.PureComponent`.
-pureComponent :: forall props state snapshot given spec.
-  ReactPureComponentSpec (Record props) (Record state) snapshot given spec =>
-  String ->
-  ReactClassConstructor (Record props) (Record state) given ->
-  ReactClass (Record props)
+pureComponent
+  :: forall props state snapshot given spec
+   . ReactPureComponentSpec (Record props) (Record state) snapshot given spec
+  => String
+  -> ReactClassConstructor (Record props) (Record state) given
+  -> ReactClass (Record props)
 pureComponent = pureComponentImpl
 
 -- | Like `pureComponent`, but takes a `getDerivedStateFromProps` handler.
-pureComponentWithDerivedState :: forall props state snapshot given spec.
-  ReactPureComponentSpec (Record props) (Record state) snapshot given spec =>
-  String ->
-  (Record props -> Record state -> Record state) ->
-  ReactClassConstructor (Record props) (Record state) given ->
-  ReactClass (Record props)
+pureComponentWithDerivedState
+  :: forall props state snapshot given spec
+   . ReactPureComponentSpec (Record props) (Record state) snapshot given spec
+  => String
+  -> (Record props -> Record state -> Record state)
+  -> ReactClassConstructor (Record props) (Record state) given
+  -> ReactClass (Record props)
 pureComponentWithDerivedState = componentWithDerivedStateImpl
 
-foreign import componentImpl :: forall this props r.
-  String ->
-  (this -> Effect r) ->
-  ReactClass props
+foreign import componentImpl
+  :: forall this props r
+   . String
+  -> (this -> Effect r)
+  -> ReactClass props
 
-foreign import componentWithDerivedStateImpl :: forall this props state r.
-  String ->
-  (props -> state -> state) ->
-  (this -> Effect r) ->
-  ReactClass props
+foreign import componentWithDerivedStateImpl
+  :: forall this props state r
+   . String
+  -> (props -> state -> state)
+  -> (this -> Effect r)
+  -> ReactClass props
 
-foreign import pureComponentImpl :: forall this props r.
-  String ->
-  (this -> Effect r) ->
-  ReactClass props
+foreign import pureComponentImpl
+  :: forall this props r
+   . String
+  -> (this -> Effect r)
+  -> ReactClass props
 
-foreign import pureComponentWithDerivedStateImpl :: forall this props state r.
-  String ->
-  (props -> state -> state) ->
-  (this -> Effect r) ->
-  ReactClass props
+foreign import pureComponentWithDerivedStateImpl
+  :: forall this props state r
+   . String
+  -> (props -> state -> state)
+  -> (this -> Effect r)
+  -> ReactClass props
 
-foreign import statelessComponent :: forall props.
-  (Record props -> ReactElement) ->
-  ReactClass (Record props)
+foreign import statelessComponent
+  :: forall props
+   . (Record props -> ReactElement)
+  -> ReactClass (Record props)
 
 -- | React class for components.
 foreign import data ReactClass :: Type -> Type
@@ -258,73 +267,83 @@ type role ReactClass representational
 foreign import fragment :: ReactClass { children :: Children }
 
 -- | Read the component props.
-foreign import getProps :: forall props state.
-  ReactThis props state ->
-  Effect props
+foreign import getProps
+  :: forall props state
+   . ReactThis props state
+  -> Effect props
 
-foreign import setStateImpl :: forall props state update.
-  ReactThis props state ->
-  update ->
-  Effect Unit
+foreign import setStateImpl
+  :: forall props state update
+   . ReactThis props state
+  -> update
+  -> Effect Unit
 
-foreign import setStateWithCallbackImpl :: forall props state update.
-  ReactThis props state ->
-  update ->
-  Effect Unit ->
-  Effect Unit
+foreign import setStateWithCallbackImpl
+  :: forall props state update
+   . ReactThis props state
+  -> update
+  -> Effect Unit
+  -> Effect Unit
 
 -- | Get the component state.
-foreign import getState :: forall props state.
-  ReactThis props state ->
-  Effect state
+foreign import getState
+  :: forall props state
+   . ReactThis props state
+  -> Effect state
 
 -- | Update component state given some sub-set of state properties.
-setState :: forall props given rest all.
-  Row.Union given rest all =>
-  ReactThis props (Record all) ->
-  Record given ->
-  Effect Unit
+setState
+  :: forall props given rest all
+   . Row.Union given rest all
+  => ReactThis props (Record all)
+  -> Record given
+  -> Effect Unit
 setState = setStateImpl
 
 -- | Update component state given some sub-set of state properties, while
 -- | also invoking a callback when applied.
-setStateWithCallback :: forall props given rest all.
-  Row.Union given rest all =>
-  ReactThis props (Record all) ->
-  Record given ->
-  Effect Unit ->
-  Effect Unit
+setStateWithCallback
+  :: forall props given rest all
+   . Row.Union given rest all
+  => ReactThis props (Record all)
+  -> Record given
+  -> Effect Unit
+  -> Effect Unit
 setStateWithCallback = setStateWithCallbackImpl
 
 -- | Update component state.
-writeState :: forall props all.
-  ReactThis props (Record all) ->
-  Record all ->
-  Effect Unit
+writeState
+  :: forall props all
+   . ReactThis props (Record all)
+  -> Record all
+  -> Effect Unit
 writeState = setStateImpl
 
 -- | Update component state, while also invoking a callback when applied.
-writeStateWithCallback :: forall props all.
-  ReactThis props (Record all) ->
-  Record all ->
-  Effect Unit ->
-  Effect Unit
+writeStateWithCallback
+  :: forall props all
+   . ReactThis props (Record all)
+  -> Record all
+  -> Effect Unit
+  -> Effect Unit
 writeStateWithCallback = setStateWithCallbackImpl
 
 -- | Update component state given a modification function.
-modifyState :: forall props state.
-  ReactThis props state ->
-  (state -> state) ->
-  Effect Unit
+modifyState
+  :: forall props state
+   . ReactThis props state
+  -> (state -> state)
+  -> Effect Unit
 modifyState = setStateImpl
 
 -- | Update component state given a modification function, while also invoking
 -- | a callback when applied.
-modifyStateWithCallback :: forall props state.
-  ReactThis props state ->
-  (state -> state) ->
-  Effect Unit ->
-  Effect Unit
+modifyStateWithCallback
+  :: forall props state
+   . ReactThis props state
+  -> (state -> state)
+  -> Effect Unit
+  -> Effect Unit
 modifyStateWithCallback = setStateWithCallbackImpl
 
 -- | Force render of a react component.
@@ -332,10 +351,11 @@ forceUpdate :: forall props state. ReactThis props state -> Effect Unit
 forceUpdate this = forceUpdateWithCallback this (pure unit)
 
 -- | Force render and then run an Effect.
-foreign import forceUpdateWithCallback :: forall props state.
-  ReactThis props state ->
-  Effect Unit ->
-  Effect Unit
+foreign import forceUpdateWithCallback
+  :: forall props state
+   . ReactThis props state
+  -> Effect Unit
+  -> Effect Unit
 
 class ReactPropFields (required :: Row Type) (given :: Row Type)
 
@@ -352,75 +372,100 @@ instance reactPropFields ::
   ReactPropFields required given
 
 -- | Create an element from a React class spreading the children array. Used when the children are known up front.
-createElement :: forall required given.
-  ReactPropFields required given =>
-  ReactClass { children :: Children | required } ->
-  { | given } ->
-  Array ReactElement ->
-  ReactElement
+createElement
+  :: forall required given
+   . ReactPropFields required given
+  => ReactClass { children :: Children | required }
+  -> { | given }
+  -> Array ReactElement
+  -> ReactElement
 createElement = createElementImpl
 
 -- | An unsafe version of `createElement` which does not enforce the reserved
 -- | properties "key" and "ref".
-unsafeCreateElement :: forall props.
-  ReactClass { children :: Children | props } ->
-  { | props } ->
-  Array ReactElement ->
-  ReactElement
+unsafeCreateElement
+  :: forall props
+   . ReactClass { children :: Children | props }
+  -> { | props }
+  -> Array ReactElement
+  -> ReactElement
 unsafeCreateElement = createElementImpl
 
 -- | Create an element from a React class passing the children array. Used for a dynamic array of children.
-createElementDynamic :: forall required given.
-  ReactPropFields required given =>
-  ReactClass { children :: Children | required } ->
-  { | given } ->
-  Array ReactElement ->
-  ReactElement
+createElementDynamic
+  :: forall required given
+   . ReactPropFields required given
+  => ReactClass { children :: Children | required }
+  -> { | given }
+  -> Array ReactElement
+  -> ReactElement
 createElementDynamic = createElementDynamicImpl
 
 -- | An unsafe version of `createElementDynamic` which does not enforce the reserved
 -- | properties "key" and "ref".
-unsafeCreateElementDynamic :: forall props.
-  ReactClass { children :: Children | props } ->
-  { | props } ->
-  Array ReactElement ->
-  ReactElement
+unsafeCreateElementDynamic
+  :: forall props
+   . ReactClass { children :: Children | props }
+  -> { | props }
+  -> Array ReactElement
+  -> ReactElement
 unsafeCreateElementDynamic = createElementDynamicImpl
 
-foreign import createElementImpl :: forall required given children.
-  ReactClass required -> given -> Array children -> ReactElement
+foreign import createElementImpl
+  :: forall required given children
+   . ReactClass required
+  -> given
+  -> Array children
+  -> ReactElement
 
-foreign import createElementDynamicImpl :: forall required given children.
-  ReactClass required -> given -> Array children -> ReactElement
+foreign import createElementDynamicImpl
+  :: forall required given children
+   . ReactClass required
+  -> given
+  -> Array children
+  -> ReactElement
 
 -- | Create an element from a React class that does not require children. Additionally it can be used
 -- | when the children are represented /only/ through the `children` prop - for instance, a `ContextConsumer`
 -- | would be turned into a `ReactElement` with `createLeafElement someContext.consumer { children: \x -> ... }`.
-createLeafElement :: forall required given.
-  ReactPropFields required given =>
-  ReactClass { | required } ->
-  { | given } ->
-  ReactElement
+createLeafElement
+  :: forall required given
+   . ReactPropFields required given
+  => ReactClass { | required }
+  -> { | given }
+  -> ReactElement
 createLeafElement = createLeafElementImpl
 
 -- | An unsafe version of `createLeafElement` which does not enforce the reserved
 -- | properties "key" and "ref".
-unsafeCreateLeafElement :: forall props.
-  ReactClass props ->
-  props ->
-  ReactElement
+unsafeCreateLeafElement
+  :: forall props
+   . ReactClass props
+  -> props
+  -> ReactElement
 unsafeCreateLeafElement = createLeafElementImpl
 
-foreign import createLeafElementImpl :: forall required given.
-  ReactClass required -> given -> ReactElement
+foreign import createLeafElementImpl
+  :: forall required given
+   . ReactClass required
+  -> given
+  -> ReactElement
 
 -- | Create an element from a tag name spreading the children array. Used when the children are known up front.
-foreign import createElementTagName :: forall props.
-  TagName -> props -> Array ReactElement -> ReactElement
+foreign import createElementTagName
+  :: forall props
+   . TagName
+  -> props
+  -> Array ReactElement
+  -> ReactElement
 
 -- | Create an element from a tag name passing the children array. Used for a dynamic array of children.
-foreign import createElementTagNameDynamic :: forall props.
-  TagName -> props -> Array ReactElement -> ReactElement
+foreign import createElementTagNameDynamic
+  :: forall props
+   . TagName
+  -> props
+  -> Array ReactElement
+  -> ReactElement
 
 -- | Internal representation for the children elements passed to a component
 foreign import data Children :: Type

--- a/src/React/DOM.purs
+++ b/src/React/DOM.purs
@@ -6,15 +6,15 @@ import Unsafe.Coerce (unsafeCoerce)
 
 newtype IsDynamic = IsDynamic Boolean
 
-mkDOM ::
-  IsDynamic -> TagName -> Array Props -> Array ReactElement -> ReactElement
+mkDOM
+  :: IsDynamic -> TagName -> Array Props -> Array ReactElement -> ReactElement
 mkDOM dynamic tag props = createElement tag (unsafeFromPropsArray props)
   where
   createElement :: TagName -> Array Props -> Array ReactElement -> ReactElement
   createElement =
     case dynamic of
-         IsDynamic false -> createElementTagName
-         IsDynamic true -> createElementTagNameDynamic
+      IsDynamic false -> createElementTagName
+      IsDynamic true -> createElementTagNameDynamic
 
 text :: String -> ReactElement
 text = unsafeCoerce

--- a/src/React/DOM.purs
+++ b/src/React/DOM.purs
@@ -6,8 +6,7 @@ import Unsafe.Coerce (unsafeCoerce)
 
 newtype IsDynamic = IsDynamic Boolean
 
-mkDOM
-  :: IsDynamic -> TagName -> Array Props -> Array ReactElement -> ReactElement
+mkDOM :: IsDynamic -> TagName -> Array Props -> Array ReactElement -> ReactElement
 mkDOM dynamic tag props = createElement tag (unsafeFromPropsArray props)
   where
   createElement :: TagName -> Array Props -> Array ReactElement -> ReactElement

--- a/src/React/DOM/Dynamic.purs
+++ b/src/React/DOM/Dynamic.purs
@@ -1,8 +1,8 @@
 module React.DOM.Dynamic where
 
 import React (ReactElement)
-import React.DOM.Props (Props)
 import React.DOM as DOM
+import React.DOM.Props (Props)
 
 text :: String -> ReactElement
 text = DOM.text

--- a/src/React/DOM/Props.purs
+++ b/src/React/DOM/Props.purs
@@ -6,13 +6,13 @@ import Effect (Effect)
 import Effect.Uncurried (mkEffectFn1)
 import React.Ref as Ref
 import React.SyntheticEvent
-  ( SyntheticEvent
-  , SyntheticAnimationEvent
+  ( SyntheticAnimationEvent
   , SyntheticClipboardEvent
   , SyntheticCompositionEvent
+  , SyntheticEvent
+  , SyntheticFocusEvent
   , SyntheticInputEvent
   , SyntheticKeyboardEvent
-  , SyntheticFocusEvent
   , SyntheticMouseEvent
   , SyntheticTouchEvent
   , SyntheticTransitionEvent

--- a/src/React/Ref.purs
+++ b/src/React/Ref.purs
@@ -33,27 +33,21 @@ foreign import data RefHandler :: Type -> Type
 
 type role RefHandler representational
 
-
 foreign import createRef :: forall a. Effect (Ref a)
 
 foreign import liftCallbackRef :: forall a. Ref a -> Ref a
 
-
 createNodeRef :: Effect (Ref NativeNode)
 createNodeRef = createRef
-
 
 createInstanceRef :: Effect (Ref ReactInstance)
 createInstanceRef = createRef
 
-
 fromRef :: forall a. Ref a -> RefHandler a
 fromRef = unsafeCoerce
 
-
 fromEffect :: forall a. (Ref a -> Effect Unit) -> RefHandler a
 fromEffect f = unsafeCoerce $ mkEffectFn1 (f <<< liftCallbackRef)
-
 
 foreign import getCurrentRef_ :: forall a. EffectFn1 (Ref a) (Nullable a)
 

--- a/src/React/Ref.purs
+++ b/src/React/Ref.purs
@@ -11,11 +11,12 @@ module React.Ref
   ) where
 
 import Prelude
-import Effect (Effect)
+
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable)
 import Data.Nullable as Nullable
-import Effect.Uncurried (EffectFn1, runEffectFn1, mkEffectFn1)
+import Effect (Effect)
+import Effect.Uncurried (EffectFn1, mkEffectFn1, runEffectFn1)
 import Unsafe.Coerce (unsafeCoerce)
 
 --- | An instance of a React class.

--- a/src/React/SyntheticEvent.purs
+++ b/src/React/SyntheticEvent.purs
@@ -149,107 +149,118 @@ foreign import data NativeAbstractView :: Type
 foreign import data NativeTouchList :: Type
 
 type SyntheticEvent' r
-  = ( bubbles :: Boolean
-    , cancelable :: Boolean
-    , currentTarget :: NativeEventTarget
-    , defaultPrevented :: Boolean
-    , eventPhase :: Number
-    , isTrusted :: Boolean
-    , nativeEvent :: NativeEvent
-    , target :: NativeEventTarget
-    , timeStamp :: Number
-    , type :: String
-    | r
-    )
+  =
+  ( bubbles :: Boolean
+  , cancelable :: Boolean
+  , currentTarget :: NativeEventTarget
+  , defaultPrevented :: Boolean
+  , eventPhase :: Number
+  , isTrusted :: Boolean
+  , nativeEvent :: NativeEvent
+  , target :: NativeEventTarget
+  , timeStamp :: Number
+  , type :: String
+  | r
+  )
 
 type SyntheticAnimationEvent' r
-  = ( animationName :: String
-    , pseudoElement :: String
-    , elapsedTime :: Number
-    | r
-    )
+  =
+  ( animationName :: String
+  , pseudoElement :: String
+  , elapsedTime :: Number
+  | r
+  )
 
 type SyntheticClipboardEvent' r
-  = ( clipboardData :: NativeDataTransfer
-    | r
-    )
+  =
+  ( clipboardData :: NativeDataTransfer
+  | r
+  )
 
 type SyntheticCompositionEvent' r
-  = ( data :: String
-    | r
-    )
+  =
+  ( data :: String
+  | r
+  )
 
-type SyntheticFocusEvent'  r
-  = ( relatedTarget :: NativeEventTarget
-    | r
-    )
+type SyntheticFocusEvent' r
+  =
+  ( relatedTarget :: NativeEventTarget
+  | r
+  )
 
 type SyntheticKeyboardEvent' r
-  = ( altKey :: Boolean
-    , ctrlKey :: Boolean
-    , getModifierState :: String -> Boolean
-    , charCode :: Int
-    , key :: String
-    , keyCode :: Number
-    , locale :: String
-    , location :: Number
-    , metaKey :: Boolean
-    , repeat :: Boolean
-    , shiftKey :: Boolean
-    , which :: Number
-    | r
-    )
+  =
+  ( altKey :: Boolean
+  , ctrlKey :: Boolean
+  , getModifierState :: String -> Boolean
+  , charCode :: Int
+  , key :: String
+  , keyCode :: Number
+  , locale :: String
+  , location :: Number
+  , metaKey :: Boolean
+  , repeat :: Boolean
+  , shiftKey :: Boolean
+  , which :: Number
+  | r
+  )
 
 type SyntheticMouseEvent' r
-  = ( altKey :: Boolean
-    , button :: Number
-    , buttons :: Number
-    , clientX :: Number
-    , clientY :: Number
-    , ctrlKey :: Boolean
-    , getModifierState :: String -> Boolean
-    , metaKey :: Boolean
-    , pageX :: Number
-    , pageY :: Number
-    , relatedTarget :: NativeEventTarget
-    , screenX :: Number
-    , screenY :: Number
-    , shiftKey :: Boolean
-    | r
-    )
+  =
+  ( altKey :: Boolean
+  , button :: Number
+  , buttons :: Number
+  , clientX :: Number
+  , clientY :: Number
+  , ctrlKey :: Boolean
+  , getModifierState :: String -> Boolean
+  , metaKey :: Boolean
+  , pageX :: Number
+  , pageY :: Number
+  , relatedTarget :: NativeEventTarget
+  , screenX :: Number
+  , screenY :: Number
+  , shiftKey :: Boolean
+  | r
+  )
 
 type SyntheticTouchEvent' r
-  = ( altKey :: Boolean
-    , changedTouches :: NativeTouchList
-    , ctrlKey :: Boolean
-    , getModifierState :: String -> Boolean
-    , metaKey :: Boolean
-    , targetTouches :: NativeTouchList
-    , shiftKey :: Boolean
-    , touches :: NativeTouchList
-    | r
-    )
+  =
+  ( altKey :: Boolean
+  , changedTouches :: NativeTouchList
+  , ctrlKey :: Boolean
+  , getModifierState :: String -> Boolean
+  , metaKey :: Boolean
+  , targetTouches :: NativeTouchList
+  , shiftKey :: Boolean
+  , touches :: NativeTouchList
+  | r
+  )
 
 type SyntheticTransitionEvent' r
-  = ( propertyName :: String
-    , pseudoElement :: String
-    , elapsedTime :: Number
-    | r
-    )
+  =
+  ( propertyName :: String
+  , pseudoElement :: String
+  , elapsedTime :: Number
+  | r
+  )
 
 type SyntheticUIEvent' r
-  = ( detail :: Number
-    , view :: NativeAbstractView
-    | r
-    )
+  =
+  ( detail :: Number
+  , view :: NativeAbstractView
+  | r
+  )
 
 type SyntheticWheelEvent' r
-  = ( deltaMode :: Number
-    , deltaX :: Number
-    , deltaY :: Number
-    , deltaZ :: Number
-    | r
-    )
+  =
+  ( deltaMode :: Number
+  , deltaX :: Number
+  , deltaY :: Number
+  , deltaZ :: Number
+  | r
+  )
 
 bubbles :: forall r. SyntheticEvent_ (bubbles :: Boolean | r) -> Effect Boolean
 bubbles = get (Proxy :: Proxy "bubbles")

--- a/src/React/SyntheticEvent.purs
+++ b/src/React/SyntheticEvent.purs
@@ -98,41 +98,29 @@ import Effect (Effect)
 import Prim.Row as Row
 import Type.Proxy (Proxy(..))
 
-type SyntheticEvent
-  = SyntheticEvent_ (SyntheticEvent' ())
+type SyntheticEvent = SyntheticEvent_ (SyntheticEvent' ())
 
-type SyntheticAnimationEvent
-  = SyntheticEvent_ (SyntheticAnimationEvent' (SyntheticEvent' ()))
+type SyntheticAnimationEvent = SyntheticEvent_ (SyntheticAnimationEvent' (SyntheticEvent' ()))
 
-type SyntheticClipboardEvent
-  = SyntheticEvent_ (SyntheticClipboardEvent' (SyntheticEvent' ()))
+type SyntheticClipboardEvent = SyntheticEvent_ (SyntheticClipboardEvent' (SyntheticEvent' ()))
 
-type SyntheticCompositionEvent
-  = SyntheticEvent_ (SyntheticCompositionEvent' (SyntheticUIEvent' (SyntheticEvent' ())))
+type SyntheticCompositionEvent = SyntheticEvent_ (SyntheticCompositionEvent' (SyntheticUIEvent' (SyntheticEvent' ())))
 
-type SyntheticInputEvent
-  = SyntheticEvent_ (SyntheticUIEvent' (SyntheticEvent' ()))
+type SyntheticInputEvent = SyntheticEvent_ (SyntheticUIEvent' (SyntheticEvent' ()))
 
-type SyntheticKeyboardEvent
-  = SyntheticEvent_ (SyntheticKeyboardEvent' (SyntheticUIEvent' (SyntheticEvent' ())))
+type SyntheticKeyboardEvent = SyntheticEvent_ (SyntheticKeyboardEvent' (SyntheticUIEvent' (SyntheticEvent' ())))
 
-type SyntheticFocusEvent
-  = SyntheticEvent_ (SyntheticFocusEvent' (SyntheticUIEvent' (SyntheticEvent' ())))
+type SyntheticFocusEvent = SyntheticEvent_ (SyntheticFocusEvent' (SyntheticUIEvent' (SyntheticEvent' ())))
 
-type SyntheticMouseEvent
-  = SyntheticEvent_ (SyntheticMouseEvent' (SyntheticUIEvent' (SyntheticEvent' ())))
+type SyntheticMouseEvent = SyntheticEvent_ (SyntheticMouseEvent' (SyntheticUIEvent' (SyntheticEvent' ())))
 
-type SyntheticTouchEvent
-  = SyntheticEvent_ (SyntheticTouchEvent' (SyntheticUIEvent' (SyntheticEvent' ())))
+type SyntheticTouchEvent = SyntheticEvent_ (SyntheticTouchEvent' (SyntheticUIEvent' (SyntheticEvent' ())))
 
-type SyntheticTransitionEvent
-  = SyntheticEvent_ (SyntheticTransitionEvent' (SyntheticEvent' ()))
+type SyntheticTransitionEvent = SyntheticEvent_ (SyntheticTransitionEvent' (SyntheticEvent' ()))
 
-type SyntheticUIEvent
-  = SyntheticEvent_ (SyntheticUIEvent' (SyntheticEvent' ()))
+type SyntheticUIEvent = SyntheticEvent_ (SyntheticUIEvent' (SyntheticEvent' ()))
 
-type SyntheticWheelEvent
-  = SyntheticEvent_ (SyntheticWheelEvent' (SyntheticMouseEvent' (SyntheticEvent' ())))
+type SyntheticWheelEvent = SyntheticEvent_ (SyntheticWheelEvent' (SyntheticMouseEvent' (SyntheticEvent' ())))
 
 foreign import data SyntheticEvent_ :: Row Type -> Type
 
@@ -148,8 +136,7 @@ foreign import data NativeAbstractView :: Type
 
 foreign import data NativeTouchList :: Type
 
-type SyntheticEvent' r
-  =
+type SyntheticEvent' r =
   ( bubbles :: Boolean
   , cancelable :: Boolean
   , currentTarget :: NativeEventTarget
@@ -163,34 +150,29 @@ type SyntheticEvent' r
   | r
   )
 
-type SyntheticAnimationEvent' r
-  =
+type SyntheticAnimationEvent' r =
   ( animationName :: String
   , pseudoElement :: String
   , elapsedTime :: Number
   | r
   )
 
-type SyntheticClipboardEvent' r
-  =
+type SyntheticClipboardEvent' r =
   ( clipboardData :: NativeDataTransfer
   | r
   )
 
-type SyntheticCompositionEvent' r
-  =
+type SyntheticCompositionEvent' r =
   ( data :: String
   | r
   )
 
-type SyntheticFocusEvent' r
-  =
+type SyntheticFocusEvent' r =
   ( relatedTarget :: NativeEventTarget
   | r
   )
 
-type SyntheticKeyboardEvent' r
-  =
+type SyntheticKeyboardEvent' r =
   ( altKey :: Boolean
   , ctrlKey :: Boolean
   , getModifierState :: String -> Boolean
@@ -206,8 +188,7 @@ type SyntheticKeyboardEvent' r
   | r
   )
 
-type SyntheticMouseEvent' r
-  =
+type SyntheticMouseEvent' r =
   ( altKey :: Boolean
   , button :: Number
   , buttons :: Number
@@ -225,8 +206,7 @@ type SyntheticMouseEvent' r
   | r
   )
 
-type SyntheticTouchEvent' r
-  =
+type SyntheticTouchEvent' r =
   ( altKey :: Boolean
   , changedTouches :: NativeTouchList
   , ctrlKey :: Boolean
@@ -238,23 +218,20 @@ type SyntheticTouchEvent' r
   | r
   )
 
-type SyntheticTransitionEvent' r
-  =
+type SyntheticTransitionEvent' r =
   ( propertyName :: String
   , pseudoElement :: String
   , elapsedTime :: Number
   | r
   )
 
-type SyntheticUIEvent' r
-  =
+type SyntheticUIEvent' r =
   ( detail :: Number
   , view :: NativeAbstractView
   | r
   )
 
-type SyntheticWheelEvent' r
-  =
+type SyntheticWheelEvent' r =
   ( deltaMode :: Number
   , deltaX :: Number
   , deltaY :: Number
@@ -407,7 +384,11 @@ foreign import isPropagationStopped :: forall r. SyntheticEvent_ r -> Effect Boo
 
 foreign import persist :: forall r. SyntheticEvent_ r -> Effect Unit
 
-foreign import getModifierState :: forall r. String -> SyntheticEvent_ (getModifierState :: String -> Boolean | r) -> Effect Boolean
+foreign import getModifierState
+  :: forall r
+   . String
+  -> SyntheticEvent_ (getModifierState :: String -> Boolean | r)
+  -> Effect Boolean
 
 get
   :: forall l r s a proxy


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
