### PR TITLE
Use null for mempty ReactElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes:
+- Update the Monoid/Semigroup instance of `ReactElement` to use `null` for `mempty` instead of an empty fragment. (#187)
 
 New features:
 

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,5 @@
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/prepare-0.15/src/packages.dhall
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.4-20221208/packages.dhall
+        sha256:e3549e48d0170e14838d8f0c44172253947dcb6117b51a763f33dca34f00ba43
 
 in  upstream

--- a/src/React.js
+++ b/src/React.js
@@ -153,3 +153,11 @@ function createContext(defaultValue) {
   };
 }
 export {createContext};
+
+export var emptyReactElement = null;
+
+function isEmptyReactElement(a) {
+  return a === emptyReactElement;
+};
+
+export {isEmptyReactElement};

--- a/src/React.purs
+++ b/src/React.purs
@@ -81,11 +81,18 @@ type TagName = String
 -- | A virtual DOM node, or component.
 foreign import data ReactElement :: Type
 
+foreign import emptyReactElement :: ReactElement
+
+foreign import isEmptyReactElement :: ReactElement -> Boolean
+
 instance semigroupReactElement :: Semigroup ReactElement where
-  append a b = toElement [ a, b ]
+  append a b
+    | isEmptyReactElement a = b
+    | isEmptyReactElement b = a
+    | otherwise = toElement [ a, b ]
 
 instance monoidReactElement :: Monoid ReactElement where
-  mempty = toElement ([] :: Array ReactElement)
+  mempty = emptyReactElement
 
 -- | A mounted react component
 foreign import data ReactComponent :: Type
@@ -493,7 +500,9 @@ instance isReactElementReactElement :: IsReactElement ReactElement where
   toElement = identity
 
 instance isReactElementArray :: IsReactElement (Array ReactElement) where
-  toElement = createElement fragment {}
+  toElement = case _ of
+    [] -> mempty
+    children -> createElement fragment {} children
 
 -- | Creates a keyed fragment.
 fragmentWithKey :: String -> Array ReactElement -> ReactElement


### PR DESCRIPTION
**Description of the change**
This updates the Monoid/Semigroup instances of `ReactElement` to represent `mempty` as `null` rather than an empty fragment, which is more in line with API expectations for third-party libraries. Due to that, this can technically be considered a breaking change? However, this change is not observable within the exported purescript-react types and interface.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
